### PR TITLE
Add use_legacy_notifications parameter

### DIFF
--- a/pingdom/check_types.go
+++ b/pingdom/check_types.go
@@ -20,6 +20,7 @@ type HttpCheck struct {
 	SendNotificationWhenDown int    `json:"sendnotificationwhendown,omitempty"`
 	NotifyAgainEvery         int    `json:"notifyagainevery,omitempty"`
 	NotifyWhenBackup         bool   `json:"notifywhenbackup,omitempty"`
+	UseLegacyNotifications   bool   `json:"use_legacy_notifications,omitempty"`
 }
 
 // PingCheck represents a Pingdom ping check
@@ -36,6 +37,7 @@ type PingCheck struct {
 	SendNotificationWhenDown int    `json:"sendnotificationwhendown,omitempty"`
 	NotifyAgainEvery         int    `json:"notifyagainevery,omitempty"`
 	NotifyWhenBackup         bool   `json:"notifywhenbackup,omitempty"`
+	UseLegacyNotifications   bool   `json:"use_legacy_notifications,omitempty"`
 }
 
 // Params returns a map of parameters for an HttpCheck that can be sent along
@@ -54,7 +56,8 @@ func (ck *HttpCheck) Params() map[string]string {
 		"sendnotificationwhendown": strconv.Itoa(ck.SendNotificationWhenDown),
 		"notifyagainevery":         strconv.Itoa(ck.NotifyAgainEvery),
 		"notifywhenbackup":         strconv.FormatBool(ck.NotifyWhenBackup),
-		"type":                     "http",
+		"use_legacy_notifications": strconv.FormatBool(ck.UseLegacyNotifications),
+		"type": "http",
 	}
 }
 
@@ -93,7 +96,8 @@ func (ck *PingCheck) Params() map[string]string {
 		"sendnotificationwhendown": strconv.Itoa(ck.SendNotificationWhenDown),
 		"notifyagainevery":         strconv.Itoa(ck.NotifyAgainEvery),
 		"notifywhenbackup":         strconv.FormatBool(ck.NotifyWhenBackup),
-		"type":                     "ping",
+		"use_legacy_notifications": strconv.FormatBool(ck.UseLegacyNotifications),
+		"type": "ping",
 	}
 }
 

--- a/pingdom/check_types_test.go
+++ b/pingdom/check_types_test.go
@@ -21,7 +21,8 @@ func TestHttpCheckParams(t *testing.T) {
 		"sendnotificationwhendown": "0",
 		"notifyagainevery":         "0",
 		"notifywhenbackup":         "false",
-		"type":                     "http",
+		"use_legacy_notifications": "false",
+		"type": "http",
 	}
 
 	if !reflect.DeepEqual(params, want) {
@@ -57,7 +58,8 @@ func TestPingCheckParams(t *testing.T) {
 		"sendnotificationwhendown": "0",
 		"notifyagainevery":         "0",
 		"notifywhenbackup":         "false",
-		"type":                     "ping",
+		"use_legacy_notifications": "false",
+		"type": "ping",
 	}
 
 	if !reflect.DeepEqual(params, want) {


### PR DESCRIPTION
As mentioned elsewhere, it is necessary to pass `use_legacy_notifications` = `true` when you manipulate w/ any notification (any of `sendto*` parameters).

That parameter for some reason isn't mentioned in the spec: https://www.pingdom.com/features/api/documentation/#MethodCreate+New+Check

but in reality the API doesn't apply any changes without that parameter, even though it tells you it does.

Here's my conversation w/ Pingdom support:
https://gist.github.com/radeksimko/c6546913a8cb58352917

and a related link: https://github.com/KennethWilke/PingdomLib/issues/12