### PR TITLE
Extended NewClient to allow Multi-User auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,22 @@ This currently only supports working with basic HTTP and ping checks.
 ## Usage ##
 
 ### Client ###
-Construct a new Pingdom client:
+
+Pingdom handles single-user and multi-user accounts differently.
+
+Construct a new single-user Pingdom client:
 
 ```go
 client := pingdom.NewClient("pingdom_username", "pingdom_password", "pingdom_api_key")
 ```
+
+Construct a multi-user Pingdom client:
+
+```go
+client := pingdom.NewMultiUserClient("pingdom_username", "pingdom_password", "pingdom_api_key", "pingdom_account_email")
+```
+
+The `pingdom_account_email` variable is the email address of the owner of the multi-user account. This is passed in the `Account-Email` header to the Pingdom API.
 
 Using a Pingdom client, you can access supported services.
 

--- a/pingdom/pingdom.go
+++ b/pingdom/pingdom.go
@@ -16,12 +16,13 @@ const (
 // provides a NewClient function for convenience to initialize a client
 // with default parameters.
 type Client struct {
-	User     string
-	Password string
-	APIKey   string
-	BaseURL  *url.URL
-	client   *http.Client
-	Checks   *CheckService
+	User         string
+	Password     string
+	APIKey       string
+	AccountEmail string
+	BaseURL      *url.URL
+	client       *http.Client
+	Checks       *CheckService
 }
 
 // NewClient returns a Pingdom client with a default base URL and HTTP client
@@ -30,6 +31,13 @@ func NewClient(user string, password string, key string) *Client {
 	c := &Client{User: user, Password: password, APIKey: key, BaseURL: baseURL}
 	c.client = http.DefaultClient
 	c.Checks = &CheckService{client: c}
+	return c
+}
+
+// NewMultiUserClient extends NewClient to allow Multi-User authentication
+func NewMultiUserClient(user string, password string, key string, accountEmail string) *Client {
+	c := NewClient(user, password, key)
+	c.AccountEmail = accountEmail
 	return c
 }
 
@@ -56,6 +64,9 @@ func (pc *Client) NewRequest(method string, rsc string, params map[string]string
 	req, err := http.NewRequest(method, baseUrl.String(), nil)
 	req.SetBasicAuth(pc.User, pc.Password)
 	req.Header.Add("App-Key", pc.APIKey)
+	if pc.AccountEmail != "" {
+		req.Header.Add("Account-Email", pc.AccountEmail)
+	}
 	return req, err
 }
 

--- a/pingdom/pingdom_test.go
+++ b/pingdom/pingdom_test.go
@@ -53,6 +53,13 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
+func TestNewMultiUserClient(t *testing.T) {
+	c := NewMultiUserClient("user", "password", "key", "account_email")
+	if c.AccountEmail == "" {
+		t.Errorf("NewMultiUserClient failed to set AccountEmail property")
+	}
+}
+
 func TestNewRequest(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
# Why

Pingdom has single-user and multi-user accounts. When using a multi-user account you need to supply the account owner email in the `Account-Email` header when calling the API. We received this error message when using this library in conjuction with the [terraform-provider-pingdom](https://github.com/russellcardullo/terraform-provider-pingdom) library:

```
Error applying plan:

2 error(s) occurred:

* pingdom_check.ping_example: 403 Forbidden: Not permitted for account type.
* pingdom_check.example: 403 Forbidden: Not permitted for account type.

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```

We want to be able to authenticate in multi-user Pingdom accounts. For this we need to capture an `AccountEmail` variable, which is the email address of the account holder.

# What

A NewMultiUserClient constructor has been created, which extends the existing NewClient constructor and allows the AccountEmail variable to be passed. This will be passed in the `Account-Email` header when making API calls.

Anything using this library has to make its own decision on whether to use the `NewClient` or `NewMultiUserClient` constructor.

# How to review

To be reviewed in conjuction with the [pull request on the terraform-provider-pingdom](https://github.com/russellcardullo/terraform-provider-pingdom/pull/1) repo. 