### PR TITLE
Fix panic caused by closing nil request body

### DIFF
--- a/pingdom/check.go
+++ b/pingdom/check.go
@@ -46,7 +46,7 @@ func (cs *CheckService) List() ([]CheckResponse, error) {
 	return m.Checks, err
 }
 
-// Create a new check.  This function will validate the given check param
+// Create a new check. This function will validate the given check param
 // to ensure that it contains correct values before submitting the request
 // Returns a CheckResponse object representing the response from Pingdom.
 // Note that Pingdom does not return a full check object so in the returned

--- a/pingdom/check.go
+++ b/pingdom/check.go
@@ -29,10 +29,10 @@ func (cs *CheckService) List() ([]CheckResponse, error) {
 	}
 
 	resp, err := cs.client.client.Do(req)
-	defer resp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if err := validateResponse(resp); err != nil {
 		return nil, err


### PR DESCRIPTION
We are experiencing lots of panics recently. This happens when the Pingdom API, which is not reachable quite frequently, is not available. This PR fixes the code causing the panic by preventing closing a nil request body.

```
Oct 05 11:07:31 0b04f612c4d4826f docker[21422]: panic: runtime error: invalid memory address or nil pointer dereference
Oct 05 11:07:31 0b04f612c4d4826f docker[21422]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x534be8]
Oct 05 11:07:31 0b04f612c4d4826f docker[21422]: goroutine 11 [running]:
Oct 05 11:07:31 0b04f612c4d4826f docker[21422]: panic(0x778b80, 0xc420012030)
Oct 05 11:07:31 0b04f612c4d4826f docker[21422]: /usr/local/go/src/runtime/panic.go:500 +0x1a1
Oct 05 11:07:31 0b04f612c4d4826f docker[21422]: github.com/russellcardullo/go-pingdom/pingdom.(*CheckService).List(0xc4200340b8, 0x0, 0x0, 0x0, 0x0, 0x0)
Oct 05 11:07:31 0b04f612c4d4826f docker[21422]: /usr/code/.gobuild/src/github.com/russellcardullo/go-pingdom/pingdom/check.go:32 +0x108
Oct 05 11:07:31 0b04f612c4d4826f docker[21422]: github.com/giantswarm/prometheus-pingdom-exporter/cmd.serverRun.func1(0xc42000a9c0)
Oct 05 11:07:31 0b04f612c4d4826f docker[21422]: /usr/code/.gobuild/src/github.com/giantswarm/prometheus-pingdom-exporter/cmd/server.go:76 +0x65
Oct 05 11:07:31 0b04f612c4d4826f docker[21422]: created by github.com/giantswarm/prometheus-pingdom-exporter/cmd.serverRun
Oct 05 11:07:31 0b04f612c4d4826f docker[21422]: /usr/code/.gobuild/src/github.com/giantswarm/prometheus-pingdom-exporter/cmd/server.go:133 +0xca
```