### PR TITLE
Add support for tagging checks

### DIFF
--- a/pingdom/check_types.go
+++ b/pingdom/check_types.go
@@ -31,6 +31,7 @@ type HttpCheck struct {
 	PostData                 string            `json:"postdata,omitempty"`
 	RequestHeaders           map[string]string `json:"requestheaders,omitempty"`
 	ContactIds               []int             `json:"contactids,omitempty"`
+	Tags                     string            `json:"tags,omitempty"`
 }
 
 // PingCheck represents a Pingdom ping check
@@ -72,6 +73,7 @@ func (ck *HttpCheck) PutParams() map[string]string {
 		"encryption": strconv.FormatBool(ck.Encryption),
 		"postdata":   ck.PostData,
 		"contactids": intListToCDString(ck.ContactIds),
+		"tags":       ck.Tags,
 	}
 
 	// Ignore port is not defined

--- a/pingdom/check_types_test.go
+++ b/pingdom/check_types_test.go
@@ -41,6 +41,7 @@ func TestHttpCheckPutParams(t *testing.T) {
 		"shouldnotcontain": "",
 		"postdata":         "",
 		"contactids":       "11111111,22222222",
+		"tags":             "",
 	}
 
 	if !reflect.DeepEqual(params, want) {


### PR DESCRIPTION
Hi, 

for our DataDog Integration with Pingdom we rely on tagged checks. This commit adds support for optionally tagging a check. 

Cheers,

Johannes

- 

- 