### PR TITLE
Added support for the Public Report API

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,8 +4,8 @@
 [[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
-  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
-  version = "v1.1.0"
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
 
 [[projects]]
   name = "github.com/pmezard/go-difflib"
@@ -16,8 +16,8 @@
 [[projects]]
   name = "github.com/stretchr/testify"
   packages = ["assert"]
-  revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
-  version = "v1.2.1"
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/README.md
+++ b/README.md
@@ -227,3 +227,32 @@ Delete a team:
 ```go
 team, err := client.Teams.Delete(12345)
 ```
+
+### PublicReportService ###
+
+This service manages the pingdom public report.  The public report is a
+publicly-visible list of checks, and this API can be used to List those
+checks, Publish checks to the public report or Withdrawl them.
+
+More information on the Public Report from Pingdom: https://www.pingdom.com/resources/api/2.1/#ResourceReports.public
+
+> Note: There is only one "public report", and it cannot be deleted.  To remove the public report, you must list all the checks and withdrawl them one-by-one.
+
+Get a list of all published checks in the public report:
+
+```go
+checks, err := client.PublicReport.List()
+fmt.Println("Checks:", checks) // [{ID Name ReportURL} ...]
+```
+
+Publish a check to the public report:
+
+```go
+_, err := client.PublicReport.PublishCheck(12345)
+```
+
+Withdrawl a check from the public report:
+
+```go
+_, err := client.PublicReport.WithdrawlCheck(12345)
+```

--- a/pingdom/api_responses.go
+++ b/pingdom/api_responses.go
@@ -101,6 +101,12 @@ type TeamDeleteResponse struct {
 	Success bool `json:"success"`
 }
 
+type PublicReportResponse struct {
+	ID        int    `json:"checkid"`
+	Name      string `json:"checkname"`
+	ReportURL string `json:"reporturl"`
+}
+
 func (c *CheckResponseType) UnmarshalJSON(b []byte) error {
 	var raw interface{}
 
@@ -168,6 +174,10 @@ type listProbesJsonResponse struct {
 
 type listTeamsJsonResponse struct {
 	Teams []TeamResponse `json:"teams"`
+}
+
+type listPublicReportsJsonResponse struct {
+	Checks []PublicReportResponse `json:"public"`
 }
 
 type checkDetailsJsonResponse struct {

--- a/pingdom/pingdom.go
+++ b/pingdom/pingdom.go
@@ -26,6 +26,7 @@ type Client struct {
 	Maintenances *MaintenanceService
 	Probes       *ProbeService
 	Teams        *TeamService
+	PublicReport *PublicReportService
 }
 
 // NewClient returns a Pingdom client with a default base URL and HTTP client
@@ -37,6 +38,7 @@ func NewClient(user string, password string, key string) *Client {
 	c.Maintenances = &MaintenanceService{client: c}
 	c.Probes = &ProbeService{client: c}
 	c.Teams = &TeamService{client: c}
+	c.PublicReport = &PublicReportService{client: c}
 	return c
 }
 

--- a/pingdom/public_report.go
+++ b/pingdom/public_report.go
@@ -1,0 +1,68 @@
+package pingdom
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"strconv"
+)
+
+// PublicReportService provides an interface to Pingdom reports
+type PublicReportService struct {
+	client *Client
+}
+
+// List return a list of reports from Pingdom.
+func (cs *PublicReportService) List() ([]PublicReportResponse, error) {
+	req, err := cs.client.NewRequest("GET", "/reports.public", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := cs.client.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if err := validateResponse(resp); err != nil {
+		return nil, err
+	}
+
+	bodyBytes, _ := ioutil.ReadAll(resp.Body)
+	bodyString := string(bodyBytes)
+
+	t := &listPublicReportsJsonResponse{}
+	err = json.Unmarshal([]byte(bodyString), &t)
+
+	return t.Checks, err
+}
+
+// Publish is used to activate a check on the public report
+func (cs *PublicReportService) PublishCheck(id int) (*PingdomResponse, error) {
+	req, err := cs.client.NewRequest("PUT", "/reports.public/"+strconv.Itoa(id), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	t := &PingdomResponse{}
+	_, err = cs.client.Do(req, t)
+	if err != nil {
+		return nil, err
+	}
+	return t, err
+}
+
+// Withdrawl is used to deactivate a check on the public report
+func (cs *PublicReportService) WithdrawlCheck(id int) (*PingdomResponse, error) {
+	req, err := cs.client.NewRequest("DELETE", "/reports.public/"+strconv.Itoa(id), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	t := &PingdomResponse{}
+	_, err = cs.client.Do(req, t)
+	if err != nil {
+		return nil, err
+	}
+	return t, err
+}

--- a/pingdom/public_report_test.go
+++ b/pingdom/public_report_test.go
@@ -1,0 +1,98 @@
+package pingdom
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPublicReportList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/reports.public", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+		    "public": [
+		        {
+		            "checkid": 3276510,
+		            "checkname": "Foo Check 1",
+		            "reporturl": "http://stats.pingdom.com/a1sdfrg20clt/3276510"
+		        },
+		        {
+		            "checkid": 3276511,
+		            "checkname": "Foo Check 2",
+		            "reporturl": "http://stats.pingdom.com/a1sdfrg20clt/3276511"
+		        },
+		        {
+		            "checkid": 3276514,
+		            "checkname": "Foo Check 3",
+		            "reporturl": "http://stats.pingdom.com/a1sdfrg20clt/3276514"
+		        },
+		        {
+		            "checkid": 3276515,
+		            "checkname": "Foo Check 4",
+		            "reporturl": "http://stats.pingdom.com/a1sdfrg20clt/3276515"
+		        }
+			]
+		}`)
+	})
+	want := []PublicReportResponse{
+		{
+			ID:        3276510,
+			Name:      "Foo Check 1",
+			ReportURL: "http://stats.pingdom.com/a1sdfrg20clt/3276510",
+		},
+		{
+			ID:        3276511,
+			Name:      "Foo Check 2",
+			ReportURL: "http://stats.pingdom.com/a1sdfrg20clt/3276511",
+		},
+		{
+			ID:        3276514,
+			Name:      "Foo Check 3",
+			ReportURL: "http://stats.pingdom.com/a1sdfrg20clt/3276514",
+		},
+		{
+			ID:        3276515,
+			Name:      "Foo Check 4",
+			ReportURL: "http://stats.pingdom.com/a1sdfrg20clt/3276515",
+		},
+	}
+
+	checks, err := client.PublicReport.List()
+	assert.NoError(t, err)
+	assert.Equal(t, want, checks, "PublicReport.List() should return correct result")
+}
+
+func TestPublicReportPublishCheck(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/reports.public/12345", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		fmt.Fprint(w, `{"message": "Check published"}`)
+	})
+	want := &PingdomResponse{Message: "Check published"}
+
+	msg, err := client.PublicReport.PublishCheck(12345)
+	assert.NoError(t, err)
+	assert.Equal(t, want, msg, "PublicReport.PublishCheck() should return correct result")
+}
+
+func TestPublicReportWithdrawlCheck(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/reports.public/12345", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		fmt.Fprint(w, `{"message": "Check published"}`)
+	})
+	want := &PingdomResponse{Message: "Check published"}
+
+	msg, err := client.PublicReport.WithdrawlCheck(12345)
+	assert.NoError(t, err)
+	assert.Equal(t, want, msg, "PublicReport.WithdrawlCheck() should return correct result")
+}


### PR DESCRIPTION
This PR adds a `PublicReportService` accessible via `client.PublicReport`, which allows you to list the checks included in the public report (`List()`), publish checks to the report (`PublishCheck()`) and withdrawl checks from the report (`WithdrawlCheck()`).

[CC @tiddnet]