### PR TITLE
Added TCP Checks support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 pingdom-go is a Go client library for the Pingdom API.
 
-This currently supports working with basic HTTP (with specific details)
-and ping checks.
+This currently supports working with basic HTTP (with specific details), ping checks and TCP checks.
 
 **Build Status:** [![Build Status](https://travis-ci.org/russellcardullo/go-pingdom.svg?branch=master)](https://travis-ci.org/russellcardullo/go-pingdom)
 
@@ -58,6 +57,13 @@ fmt.Println("Created check:", check) // {ID, Name}
 Create a new Ping check:
 ```go
 newCheck := pingdom.PingCheck{Name: "Test Check", Hostname: "example.com", Resolution: 5}
+check, err := client.Checks.Create(&newCheck)
+fmt.Println("Created check:", check) // {ID, Name}
+```
+
+Create a new TCP check:
+```go
+newCheck := pingdom.TCPCheck{Name: "Test Check", Hostname: "example.com", Port: 25, StringToSend: "HELO foo.com", StringToExpect: "250 mail.test.com", Resolution: 5}
 check, err := client.Checks.Create(&newCheck)
 fmt.Println("Created check:", check) // {ID, Name}
 ```

--- a/pingdom/check_types.go
+++ b/pingdom/check_types.go
@@ -46,6 +46,24 @@ type PingCheck struct {
 	TeamIds                  []int  `json:"teamids,omitempty"`
 }
 
+// TCPCheck represents a Pingdom TCP check
+type TCPCheck struct {
+	Name                     string `json:"name"`
+	Hostname                 string `json:"hostname,omitempty"`
+	Resolution               int    `json:"resolution,omitempty"`
+	Paused                   bool   `json:"paused,omitempty"`
+	SendNotificationWhenDown int    `json:"sendnotificationwhendown,omitempty"`
+	NotifyAgainEvery         int    `json:"notifyagainevery,omitempty"`
+	NotifyWhenBackup         bool   `json:"notifywhenbackup,omitempty"`
+	IntegrationIds           []int  `json:"integrationids,omitempty"`
+	ProbeFilters             string `json:"probe_filters,omitempty"`
+	UserIds                  []int  `json:"userids,omitempty"`
+	TeamIds                  []int  `json:"teamids,omitempty"`
+	Port                     int    `json:"port"`
+	StringToSend             string `json:"stringtosend,omitifempty"`
+	StringToExpect           string `json:"stringtoexpect,omitifempty"`
+}
+
 // Params returns a map of parameters for an HttpCheck that can be sent along
 // with an HTTP PUT request
 func (ck *HttpCheck) PutParams() map[string]string {
@@ -143,19 +161,24 @@ func (ck *HttpCheck) Valid() error {
 // Params returns a map of parameters for a PingCheck that can be sent along
 // with an HTTP PUT request
 func (ck *PingCheck) PutParams() map[string]string {
-	return map[string]string{
-		"name":                     ck.Name,
-		"host":                     ck.Hostname,
-		"resolution":               strconv.Itoa(ck.Resolution),
-		"paused":                   strconv.FormatBool(ck.Paused),
-		"sendnotificationwhendown": strconv.Itoa(ck.SendNotificationWhenDown),
-		"notifyagainevery":         strconv.Itoa(ck.NotifyAgainEvery),
-		"notifywhenbackup":         strconv.FormatBool(ck.NotifyWhenBackup),
-		"integrationids":           intListToCDString(ck.IntegrationIds),
-		"probe_filters":            ck.ProbeFilters,
-		"userids":                  intListToCDString(ck.UserIds),
-		"teamids":                  intListToCDString(ck.TeamIds),
+	m := map[string]string{
+		"name":             ck.Name,
+		"host":             ck.Hostname,
+		"resolution":       strconv.Itoa(ck.Resolution),
+		"paused":           strconv.FormatBool(ck.Paused),
+		"notifyagainevery": strconv.Itoa(ck.NotifyAgainEvery),
+		"notifywhenbackup": strconv.FormatBool(ck.NotifyWhenBackup),
+		"integrationids":   intListToCDString(ck.IntegrationIds),
+		"probe_filters":    ck.ProbeFilters,
+		"userids":          intListToCDString(ck.UserIds),
+		"teamids":          intListToCDString(ck.TeamIds),
 	}
+
+	if ck.SendNotificationWhenDown != 0 {
+		m["sendnotificationwhendown"] = strconv.Itoa(ck.SendNotificationWhenDown)
+	}
+
+	return m
 }
 
 // Params returns a map of parameters for a PingCheck that can be sent along
@@ -181,6 +204,69 @@ func (ck *PingCheck) Valid() error {
 		ck.Resolution != 30 && ck.Resolution != 60 {
 		return fmt.Errorf("Invalid value %v for `Resolution`.  Allowed values are [1,5,15,30,60].", ck.Resolution)
 	}
+	return nil
+}
+
+// Params returns a map of parameters for a TCPCheck that can be sent along
+// with an HTTP PUT request
+func (ck *TCPCheck) PutParams() map[string]string {
+	m := map[string]string{
+		"name":             ck.Name,
+		"host":             ck.Hostname,
+		"resolution":       strconv.Itoa(ck.Resolution),
+		"paused":           strconv.FormatBool(ck.Paused),
+		"notifyagainevery": strconv.Itoa(ck.NotifyAgainEvery),
+		"notifywhenbackup": strconv.FormatBool(ck.NotifyWhenBackup),
+		"integrationids":   intListToCDString(ck.IntegrationIds),
+		"probe_filters":    ck.ProbeFilters,
+		"userids":          intListToCDString(ck.UserIds),
+		"teamids":          intListToCDString(ck.TeamIds),
+		"port":             strconv.Itoa(ck.Port),
+	}
+
+	if ck.SendNotificationWhenDown != 0 {
+		m["sendnotificationwhendown"] = strconv.Itoa(ck.SendNotificationWhenDown)
+	}
+
+	if ck.StringToSend != "" {
+		m["stringtosend"] = ck.StringToSend
+	}
+
+	if ck.StringToExpect != "" {
+		m["stringtoexpect"] = ck.StringToExpect
+	}
+
+	return m
+}
+
+// Params returns a map of parameters for a TCPCheck that can be sent along
+// with an HTTP POST request. Same as PUT.
+func (ck *TCPCheck) PostParams() map[string]string {
+	params := ck.PutParams()
+	params["type"] = "tcp"
+	return params
+}
+
+// Determine whether the TCPCheck contains valid fields.  This can be
+// used to guard against sending illegal values to the Pingdom API
+func (ck *TCPCheck) Valid() error {
+	if ck.Name == "" {
+		return fmt.Errorf("Invalid value for `Name`.  Must contain non-empty string")
+	}
+
+	if ck.Hostname == "" {
+		return fmt.Errorf("Invalid value for `Hostname`.  Must contain non-empty string")
+	}
+
+	if ck.Resolution != 1 && ck.Resolution != 5 && ck.Resolution != 15 &&
+		ck.Resolution != 30 && ck.Resolution != 60 {
+		return fmt.Errorf("Invalid value %v for `Resolution`.  Allowed values are [1,5,15,30,60].", ck.Resolution)
+	}
+
+	if ck.Port < 1 {
+		return fmt.Errorf("Invalid value for `Port`.  Must contain an integer >= 1")
+	}
+
 	return nil
 }
 

--- a/pingdom/check_types_test.go
+++ b/pingdom/check_types_test.go
@@ -113,7 +113,6 @@ func TestPingCheckPostParams(t *testing.T) {
 		"host":                     "example.com",
 		"paused":                   "false",
 		"resolution":               "0",
-		"sendnotificationwhendown": "0",
 		"notifyagainevery":         "0",
 		"notifywhenbackup":         "false",
 		"type":                     "ping",
@@ -132,5 +131,45 @@ func TestPingCheckValid(t *testing.T) {
 	assert.NoError(t, check.Valid())
 
 	badCheck := PingCheck{Name: "fake check", Hostname: "example.com"}
+	assert.Error(t, badCheck.Valid())
+}
+
+func TestTCPCheckPostParams(t *testing.T) {
+	check := TCPCheck{
+		Name:           "fake check",
+		Hostname:       "example.com",
+		IntegrationIds: []int{33333333, 44444444},
+		UserIds:        []int{123, 456},
+		TeamIds:        []int{789},
+		Port:           8080,
+		StringToSend:   "Hello World",
+		StringToExpect: "Hi there",
+	}
+	want := map[string]string{
+		"name":                     "fake check",
+		"host":                     "example.com",
+		"paused":                   "false",
+		"resolution":               "0",
+		"notifyagainevery":         "0",
+		"notifywhenbackup":         "false",
+		"type":                     "tcp",
+		"integrationids":           "33333333,44444444",
+		"probe_filters":            "",
+		"userids":                  "123,456",
+		"teamids":                  "789",
+		"port":                     "8080",
+		"stringtosend":             "Hello World",
+		"stringtoexpect":           "Hi there",
+	}
+
+	params := check.PostParams()
+	assert.Equal(t, want, params)
+}
+
+func TestTCPCheckValid(t *testing.T) {
+	check := TCPCheck{Name: "fake check", Hostname: "example.com", Resolution: 15, Port: 8080}
+	assert.NoError(t, check.Valid())
+
+	badCheck := TCPCheck{Name: "fake check", Hostname: "example.com", Resolution: 15}
 	assert.Error(t, badCheck.Valid())
 }


### PR DESCRIPTION
Added support for TCP Checks.  This includes full CRUD support on TCPCheck objects, and allows users to create TCP checks with the required `Port` and optional `StringToSend` and `StringToExpect` fields.