### PR TITLE
Make responsetime_threshold optional in Ping Put params

### DIFF
--- a/pingdom/check_types.go
+++ b/pingdom/check_types.go
@@ -180,21 +180,24 @@ func (ck *HttpCheck) Valid() error {
 // with an HTTP PUT request
 func (ck *PingCheck) PutParams() map[string]string {
 	m := map[string]string{
-		"name":                   ck.Name,
-		"host":                   ck.Hostname,
-		"resolution":             strconv.Itoa(ck.Resolution),
-		"paused":                 strconv.FormatBool(ck.Paused),
-		"notifyagainevery":       strconv.Itoa(ck.NotifyAgainEvery),
-		"notifywhenbackup":       strconv.FormatBool(ck.NotifyWhenBackup),
-		"integrationids":         intListToCDString(ck.IntegrationIds),
-		"responsetime_threshold": strconv.Itoa(ck.ResponseTimeThreshold),
-		"probe_filters":          ck.ProbeFilters,
-		"userids":                intListToCDString(ck.UserIds),
-		"teamids":                intListToCDString(ck.TeamIds),
+		"name":             ck.Name,
+		"host":             ck.Hostname,
+		"resolution":       strconv.Itoa(ck.Resolution),
+		"paused":           strconv.FormatBool(ck.Paused),
+		"notifyagainevery": strconv.Itoa(ck.NotifyAgainEvery),
+		"notifywhenbackup": strconv.FormatBool(ck.NotifyWhenBackup),
+		"integrationids":   intListToCDString(ck.IntegrationIds),
+		"probe_filters":    ck.ProbeFilters,
+		"userids":          intListToCDString(ck.UserIds),
+		"teamids":          intListToCDString(ck.TeamIds),
 	}
 
 	if ck.SendNotificationWhenDown != 0 {
 		m["sendnotificationwhendown"] = strconv.Itoa(ck.SendNotificationWhenDown)
+	}
+
+	if ck.ResponseTimeThreshold != 0 {
+		m["responsetime_threshold"] = strconv.Itoa(ck.ResponseTimeThreshold)
 	}
 
 	return m

--- a/pingdom/check_types_test.go
+++ b/pingdom/check_types_test.go
@@ -131,6 +131,31 @@ func TestPingCheckPostParams(t *testing.T) {
 	assert.Equal(t, want, params)
 }
 
+func TestPingCheckPutParams(t *testing.T) {
+	check := PingCheck{
+		Name:           "fake check",
+		Hostname:       "example.com",
+		IntegrationIds: []int{33333333, 44444444},
+		UserIds:        []int{123, 456},
+		TeamIds:        []int{789},
+	}
+	want := map[string]string{
+		"name":             "fake check",
+		"host":             "example.com",
+		"resolution":       "0",
+		"paused":           "false",
+		"notifyagainevery": "0",
+		"notifywhenbackup": "false",
+		"integrationids":   "33333333,44444444",
+		"probe_filters":    "",
+		"userids":          "123,456",
+		"teamids":          "789",
+	}
+
+	params := check.PutParams()
+	assert.Equal(t, want, params)
+}
+
 func TestPingCheckValid(t *testing.T) {
 	check := PingCheck{Name: "fake check", Hostname: "example.com", Resolution: 15}
 	assert.NoError(t, check.Valid())


### PR DESCRIPTION
If the value is not set, don't include in the put params.