### PR TITLE
 pingdom: parse team ids in check instance response

### DIFF
--- a/examples/example.go
+++ b/examples/example.go
@@ -3,18 +3,19 @@ package main
 import (
 	"fmt"
 
-	"github.com/russellcardullo/go-pingdom/pingdom"
-	"os"
-	"io/ioutil"
 	"encoding/json"
+	"io/ioutil"
+	"os"
 	"strconv"
+
+	"github.com/russellcardullo/go-pingdom/pingdom"
 )
 
 type Credentials struct {
-	User 			string `json:"user"`
-	Password 		string `json:"password"`
-	ApiKey 			string `json:"apikey"`
-	AccountEmail 	string `json:"accountEmail"`
+	User         string `json:"user"`
+	Password     string `json:"password"`
+	ApiKey       string `json:"apikey"`
+	AccountEmail string `json:"accountEmail"`
 }
 
 func getConfig() Credentials {
@@ -38,10 +39,8 @@ func getConfig() Credentials {
 	// read our opened xmlFile as a byte array.
 	byteValue, _ := ioutil.ReadAll(jsonFile)
 
-
 	// we initialize our Users array
 	var config Credentials
-
 
 	// we unmarshal our byteArray which contains our
 	// jsonFile's content into 'users' which we defined above
@@ -58,14 +57,14 @@ func userExamples() {
 
 	//Create User
 	user := pingdom.User{
-	Username : "exampleUser",
+		Username: "exampleUser",
 	}
 	u, _ := client.Users.Create(&user)
 	fmt.Println("User Id: " + strconv.Itoa(u.Id))
 
 	// Create contact info
 	contact := pingdom.Contact{
-	Email: "test@example.com",
+		Email: "test@example.com",
 	}
 	c, _ := client.Users.CreateContact(u.Id, contact)
 	fmt.Println("Contact Id: " + strconv.Itoa(c.Id))

--- a/pingdom/api_responses.go
+++ b/pingdom/api_responses.go
@@ -115,30 +115,30 @@ type SummaryPerformanceResponse struct {
 
 type SummaryPerformanceMap struct {
 	Hours []SummaryPerformanceSummary `json:"hours,omitempty"`
-	Days []SummaryPerformanceSummary `json:"days,omitempty"`
+	Days  []SummaryPerformanceSummary `json:"days,omitempty"`
 	Weeks []SummaryPerformanceSummary `json:"weeks,omitempty"`
 }
 
 type SummaryPerformanceSummary struct {
 	AvgResponse int `json:"avgresponse"`
-	Downtime int `json:"downtime"`
-	StartTime int `json:"starttime"`
+	Downtime    int `json:"downtime"`
+	StartTime   int `json:"starttime"`
 	Unmonitored int `json:"unmonitored"`
-	Uptime int `json:"uptime"`
+	Uptime      int `json:"uptime"`
 }
 
 type UserSmsResponse struct {
-	Id int `json:"id"`
-	Severity string `json:"severity"`
+	Id          int    `json:"id"`
+	Severity    string `json:"severity"`
 	CountryCode string `json:"country_code"`
-	Number string `json:"number"`
-	Provider string `json:"provider"`
+	Number      string `json:"number"`
+	Provider    string `json:"provider"`
 }
 
 type UserEmailResponse struct {
-	Id int `json:"id"`
+	Id       int    `json:"id"`
 	Severity string `json:"severity"`
-	Address string `json:"address"`
+	Address  string `json:"address"`
 }
 
 type CreateUserContactResponse struct {
@@ -147,11 +147,11 @@ type CreateUserContactResponse struct {
 
 // MaintenanceWindow represents a Pingdom Maintenance Window.
 type UsersResponse struct {
-	Id    		   int  `json:"id"`
-	Paused         string  `json:"paused,omitempty"`
-	Username       string `json:"name,omitempty"`
-	Sms			   []UserSmsResponse `json:"sms,omitempty"`
-	Email 		   []UserEmailResponse `json:"email,omitempty"`
+	Id       int                 `json:"id"`
+	Paused   string              `json:"paused,omitempty"`
+	Username string              `json:"name,omitempty"`
+	Sms      []UserSmsResponse   `json:"sms,omitempty"`
+	Email    []UserEmailResponse `json:"email,omitempty"`
 }
 
 func (c *CheckResponseType) UnmarshalJSON(b []byte) error {

--- a/pingdom/api_responses.go
+++ b/pingdom/api_responses.go
@@ -19,25 +19,36 @@ type PingdomError struct {
 
 // CheckResponse represents the json response for a check from the Pingdom API
 type CheckResponse struct {
-	ID                       int                `json:"id"`
-	Name                     string             `json:"name"`
-	Resolution               int                `json:"resolution,omitempty"`
-	SendNotificationWhenDown int                `json:"sendnotificationwhendown,omitempty"`
-	NotifyAgainEvery         int                `json:"notifyagainevery,omitempty"`
-	NotifyWhenBackup         bool               `json:"notifywhenbackup,omitempty"`
-	Created                  int64              `json:"created,omitempty"`
-	Hostname                 string             `json:"hostname,omitempty"`
-	Status                   string             `json:"status,omitempty"`
-	LastErrorTime            int64              `json:"lasterrortime,omitempty"`
-	LastTestTime             int64              `json:"lasttesttime,omitempty"`
-	LastResponseTime         int64              `json:"lastresponsetime,omitempty"`
-	Paused                   bool               `json:"paused,omitempty"`
-	IntegrationIds           []int              `json:"integrationids,omitempty"`
-	Type                     CheckResponseType  `json:"type,omitempty"`
-	Tags                     []CheckResponseTag `json:"tags,omitempty"`
-	UserIds                  []int              `json:"userids,omitempty"`
-	TeamIds                  []int              `json:"teamids,omitempty"`
-	ResponseTimeThreshold    int                `json:"responsetime_threshold,omitempty"`
+	ID                       int                 `json:"id"`
+	Name                     string              `json:"name"`
+	Resolution               int                 `json:"resolution,omitempty"`
+	SendNotificationWhenDown int                 `json:"sendnotificationwhendown,omitempty"`
+	NotifyAgainEvery         int                 `json:"notifyagainevery,omitempty"`
+	NotifyWhenBackup         bool                `json:"notifywhenbackup,omitempty"`
+	Created                  int64               `json:"created,omitempty"`
+	Hostname                 string              `json:"hostname,omitempty"`
+	Status                   string              `json:"status,omitempty"`
+	LastErrorTime            int64               `json:"lasterrortime,omitempty"`
+	LastTestTime             int64               `json:"lasttesttime,omitempty"`
+	LastResponseTime         int64               `json:"lastresponsetime,omitempty"`
+	Paused                   bool                `json:"paused,omitempty"`
+	IntegrationIds           []int               `json:"integrationids,omitempty"`
+	Type                     CheckResponseType   `json:"type,omitempty"`
+	Tags                     []CheckResponseTag  `json:"tags,omitempty"`
+	UserIds                  []int               `json:"userids,omitempty"`
+	Teams                    []CheckTeamResponse `json:"teams,omitempty"`
+	ResponseTimeThreshold    int                 `json:"responsetime_threshold,omitempty"`
+
+	// Legacy; this is not returned by the API, we backfill the value from the
+	// Teams field.
+	TeamIds []int
+}
+
+// CheckTeamResponse is a Team returned inside of a Check instance. (We can't
+// use TeamResponse because the ID returned here is an int, not a string)
+type CheckTeamResponse struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
 }
 
 type CheckResponseType struct {
@@ -70,7 +81,7 @@ type MaintenanceCheckResponse struct {
 	Tms    []int `json:"tms"`
 }
 
-// ProbeResponse represents the json response for probes from the PIngdom API
+// ProbeResponse represents the json response for probes from the Pingdom API
 type ProbeResponse struct {
 	ID         int    `json:"id"`
 	Country    string `json:"country"`
@@ -84,21 +95,21 @@ type ProbeResponse struct {
 	Region     string `json:"region"`
 }
 
-// TeamResponse represents the json response for teams from the PIngdom API
+// TeamResponse represents the json response for teams from the Pingdom API
 type TeamResponse struct {
 	ID    string `json:"id"`
 	Name  string `json:"name"`
 	Users []TeamUserResponse
 }
 
-// TeamUserResponse represents the json response for users in teams from the PIngdom API
+// TeamUserResponse represents the json response for users in teams from the Pingdom API
 type TeamUserResponse struct {
 	ID    string `json:"id"`
 	Email string `json:"email"`
 	Name  string `json:"name"`
 }
 
-// TeamDeleteResponse represents the json response for delete team from the PIngdom API
+// TeamDeleteResponse represents the json response for delete team from the Pingdom API
 type TeamDeleteResponse struct {
 	Success bool `json:"success"`
 }

--- a/pingdom/check.go
+++ b/pingdom/check.go
@@ -77,7 +77,7 @@ func (cs *CheckService) Create(check Check) (*CheckResponse, error) {
 // This returns type CheckResponse rather than Check since the
 // pingdom API does not return a complete representation of a check.
 func (cs *CheckService) Read(id int) (*CheckResponse, error) {
-	req, err := cs.client.NewRequest("GET", "/checks/"+strconv.Itoa(id), nil)
+	req, err := cs.client.NewRequest("GET", "/checks/"+strconv.Itoa(id)+"?include_teams=true", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -86,6 +86,10 @@ func (cs *CheckService) Read(id int) (*CheckResponse, error) {
 	_, err = cs.client.Do(req, m)
 	if err != nil {
 		return nil, err
+	}
+	m.Check.TeamIds = make([]int, len(m.Check.Teams))
+	for i := range m.Check.Teams {
+		m.Check.TeamIds[i] = m.Check.Teams[i].ID
 	}
 
 	return m.Check, err

--- a/pingdom/check.go
+++ b/pingdom/check.go
@@ -127,7 +127,7 @@ func (cs *CheckService) Delete(id int) (*PingdomResponse, error) {
 	return m, err
 }
 
-func (cs *CheckService) SummaryPerformance(request SummaryPerformanceRequest) (*SummaryPerformanceResponse, error){
+func (cs *CheckService) SummaryPerformance(request SummaryPerformanceRequest) (*SummaryPerformanceResponse, error) {
 	if err := request.Valid(); err != nil {
 		return nil, err
 	}

--- a/pingdom/check_test.go
+++ b/pingdom/check_test.go
@@ -79,15 +79,15 @@ func TestCheckServiceList(t *testing.T) {
 
 	want := []CheckResponse{
 		{
-			ID:                     85975,
-			Name:                   "My check 1",
-			LastErrorTime:          1297446423,
-			LastResponseTime:       355,
-			LastTestTime:           1300977363,
-			Hostname:               "example.com",
-			Resolution:             1,
-			Status:                 "up",
-			ResponseTimeThreshold:  2300,
+			ID:                    85975,
+			Name:                  "My check 1",
+			LastErrorTime:         1297446423,
+			LastResponseTime:      355,
+			LastTestTime:          1300977363,
+			Hostname:              "example.com",
+			Resolution:            1,
+			Status:                "up",
+			ResponseTimeThreshold: 2300,
 			Type: CheckResponseType{
 				Name: "http",
 			},

--- a/pingdom/check_test.go
+++ b/pingdom/check_test.go
@@ -200,6 +200,12 @@ func TestCheckServiceRead(t *testing.T) {
         "responsetime_threshold": 2300,
         "status" : "up",
         "tags": [],
+        "teams": [
+            {
+                "id": 123456,
+                "name": "Oncall"
+            }
+        ],
         "type" : {
           "http" : {
             "encryption": false,
@@ -227,6 +233,13 @@ func TestCheckServiceRead(t *testing.T) {
 		LastErrorTime:            1293143467,
 		LastTestTime:             1294064823,
 		ResponseTimeThreshold:    2300,
+		Teams: []CheckTeamResponse{
+			CheckTeamResponse{
+				Name: "Oncall",
+				ID:   123456,
+			},
+		},
+		TeamIds: []int{123456},
 		Type: CheckResponseType{
 			Name: "http",
 			HTTP: &CheckResponseHTTPDetails{

--- a/pingdom/pingdom.go
+++ b/pingdom/pingdom.go
@@ -27,7 +27,7 @@ type Client struct {
 	Probes       *ProbeService
 	Teams        *TeamService
 	PublicReport *PublicReportService
-	Users		     *UserService
+	Users        *UserService
 }
 
 // NewClient returns a Pingdom client with a default base URL and HTTP client

--- a/pingdom/user.go
+++ b/pingdom/user.go
@@ -1,10 +1,10 @@
 package pingdom
 
 import (
-	"io/ioutil"
 	"encoding/json"
-	"strconv"
 	"fmt"
+	"io/ioutil"
+	"strconv"
 )
 
 type UserService struct {
@@ -90,7 +90,7 @@ func (cs *UserService) CreateContact(userId int, contact Contact) (*CreateUserCo
 		return nil, err
 	}
 
-	req, err := cs.client.NewRequest("POST", "/users/"+ strconv.Itoa(userId), contact.PostContactParams())
+	req, err := cs.client.NewRequest("POST", "/users/"+strconv.Itoa(userId), contact.PostContactParams())
 	if err != nil {
 		return nil, err
 	}
@@ -121,6 +121,7 @@ func (cs *UserService) Update(id int, user UserApi) (*PingdomResponse, error) {
 	}
 	return m, err
 }
+
 // Update a contact by id, will change an email to sms or sms to email
 // if you provide an id for the other
 func (cs *UserService) UpdateContact(userId int, contactId int, contact Contact) (*PingdomResponse, error) {
@@ -128,7 +129,7 @@ func (cs *UserService) UpdateContact(userId int, contactId int, contact Contact)
 		return nil, err
 	}
 
-	req, err := cs.client.NewRequest("PUT",  "/users/"+strconv.Itoa(userId)+"/"+strconv.Itoa(contactId), contact.PutContactParams())
+	req, err := cs.client.NewRequest("PUT", "/users/"+strconv.Itoa(userId)+"/"+strconv.Itoa(contactId), contact.PutContactParams())
 	if err != nil {
 		return nil, err
 	}

--- a/pingdom/user_test.go
+++ b/pingdom/user_test.go
@@ -1,11 +1,12 @@
 package pingdom
 
 import (
-	"github.com/stretchr/testify/assert"
-	"testing"
-	"net/http"
 	"fmt"
+	"net/http"
 	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUserService_List(t *testing.T) {
@@ -54,27 +55,27 @@ func TestUserService_List(t *testing.T) {
 			Id:       12,
 			Paused:   "NO",
 			Username: "John Doe",
-			Sms:      []UserSmsResponse{
+			Sms: []UserSmsResponse{
 				{
-					Id: 352,
-					Severity: "HIGH",
+					Id:          352,
+					Severity:    "HIGH",
 					CountryCode: "1",
-					Number: "6095555555",
-					Provider: "nexmo",
+					Number:      "6095555555",
+					Provider:    "nexmo",
 				},
 			},
-			Email:    nil,
+			Email: nil,
 		},
 		{
 			Id:       234,
 			Paused:   "NO",
 			Username: "Jane Doe",
 			Sms:      nil,
-			Email:    []UserEmailResponse{
+			Email: []UserEmailResponse{
 				{
-					Id: 314,
+					Id:       314,
 					Severity: "HIGH",
-					Address: "test@test.com",
+					Address:  "test@test.com",
 				},
 			},
 		},
@@ -130,16 +131,16 @@ func TestUserService_Read(t *testing.T) {
 		Id:       12,
 		Paused:   "NO",
 		Username: "John Doe",
-		Sms:      []UserSmsResponse{
+		Sms: []UserSmsResponse{
 			{
-				Id: 352,
-				Severity: "HIGH",
+				Id:          352,
+				Severity:    "HIGH",
 				CountryCode: "1",
-				Number: "6095555555",
-				Provider: "nexmo",
+				Number:      "6095555555",
+				Provider:    "nexmo",
 			},
 		},
-		Email:    nil,
+		Email: nil,
 	}
 
 	users, err := client.Users.Read(12)
@@ -213,7 +214,7 @@ func TestUserService_Create(t *testing.T) {
 	}
 
 	u := User{
-		Username : "testUser",
+		Username: "testUser",
 	}
 
 	user, err := client.Users.Create(&u)
@@ -227,7 +228,7 @@ func TestUserService_CreateContact(t *testing.T) {
 
 	userId := 12941
 
-	mux.HandleFunc("/users/" + strconv.Itoa(userId), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/users/"+strconv.Itoa(userId), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		fmt.Fprint(w, `{
 			"contact_target": {
@@ -241,9 +242,9 @@ func TestUserService_CreateContact(t *testing.T) {
 	}
 
 	c := Contact{
-		Email: "test@example.com",
+		Email:       "test@example.com",
 		CountryCode: "1",
-		Number: "5559995555",
+		Number:      "5559995555",
 	}
 
 	contact, err := client.Users.CreateContact(userId, c)
@@ -257,7 +258,7 @@ func TestUserService_Delete(t *testing.T) {
 
 	userId := 12941
 
-	mux.HandleFunc("/users/" + strconv.Itoa(userId), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/users/"+strconv.Itoa(userId), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		fmt.Fprint(w, `{
 			"message":"Deletion of user was successful!"
@@ -281,7 +282,7 @@ func TestUserService_DeleteContact(t *testing.T) {
 	userId := 12941
 	contactId := 87655
 
-	mux.HandleFunc("/users/" + strconv.Itoa(userId)+"/" + strconv.Itoa(contactId), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/users/"+strconv.Itoa(userId)+"/"+strconv.Itoa(contactId), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		fmt.Fprint(w, `{
 			"message":"Deletion of contact target successful"
@@ -292,7 +293,7 @@ func TestUserService_DeleteContact(t *testing.T) {
 		Message: "Deletion of contact target successful",
 	}
 
-	response, err := client.Users.DeleteContact(userId,contactId)
+	response, err := client.Users.DeleteContact(userId, contactId)
 	assert.NoError(t, err)
 	assert.Equal(t, want, response, "Users.DeleteContact() should return PingdomResponse with message")
 
@@ -307,7 +308,7 @@ func TestUserService_Update(t *testing.T) {
 		Username: "updatedUsername",
 	}
 
-	mux.HandleFunc("/users/" + strconv.Itoa(userId), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/users/"+strconv.Itoa(userId), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		fmt.Fprint(w, `{
 			"message":"Modification of user was successful!"
@@ -334,7 +335,7 @@ func TestUserService_UpdateContact(t *testing.T) {
 		Email: "test@example.com",
 	}
 
-	mux.HandleFunc("/users/" + strconv.Itoa(userId)+"/" + strconv.Itoa(contactId), func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/users/"+strconv.Itoa(userId)+"/"+strconv.Itoa(contactId), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		fmt.Fprint(w, `{
 			"message":"Modification of contact target was successful!"
@@ -345,7 +346,7 @@ func TestUserService_UpdateContact(t *testing.T) {
 		Message: "Modification of contact target was successful!",
 	}
 
-	response, err := client.Users.UpdateContact(userId,contactId,contact)
+	response, err := client.Users.UpdateContact(userId, contactId, contact)
 	assert.NoError(t, err)
 	assert.Equal(t, want, response, "Users.UpdateContact() should return PingdomResponse with message")
 

--- a/pingdom/user_types.go
+++ b/pingdom/user_types.go
@@ -7,35 +7,35 @@ import (
 // User email represents the sms contact object in a user in
 // GET /users
 type UserSms struct {
-	Severity string `json:"severity"`
+	Severity    string `json:"severity"`
 	CountryCode string `json:"country_code"`
-	Number string `json:"number"`
-	Provider string `json:"provider"`
+	Number      string `json:"number"`
+	Provider    string `json:"provider"`
 }
 
 // User email represents the email contact object in a user in
 // GET /users
 type UserEmail struct {
 	Severity string `json:"severity"`
-	Address string `json:"address"`
+	Address  string `json:"address"`
 }
 
 // Contact represents a Pingdom contact target
 type Contact struct {
-	Severity string `json:"severitylevel"`
+	Severity    string `json:"severitylevel"`
 	CountryCode string `json:"countrycode"`
-	Number string `json:"number"`
-	Provider string `json:"provider"`
-	Email string `json:"email"`
+	Number      string `json:"number"`
+	Provider    string `json:"provider"`
+	Email       string `json:"email"`
 }
 
 // User represents a Pingdom User or Contact.
 type User struct {
-	Paused         string  `json:"paused,omitempty"`
-	Username       string `json:"name,omitempty"`
-	Primary		   string `json:"primary,omitempty"`
-	Sms			   []UserSmsResponse `json:"sms,omitempty"`
-	Email 		   []UserEmailResponse `json:"email,omitempty"`
+	Paused   string              `json:"paused,omitempty"`
+	Username string              `json:"name,omitempty"`
+	Primary  string              `json:"primary,omitempty"`
+	Sms      []UserSmsResponse   `json:"sms,omitempty"`
+	Email    []UserEmailResponse `json:"email,omitempty"`
 }
 
 func (u *User) ValidUser() error {
@@ -51,13 +51,13 @@ func (u *User) ValidUser() error {
 func (c *Contact) ValidContact() error {
 	if c.Email == "" && c.Number == "" {
 		return fmt.Errorf("you must provide either an Email or a Phone Number to create a contact target")
-}
+	}
 
 	if c.Number != "" && c.CountryCode == "" {
 		return fmt.Errorf("you must provide a Country Code if providing a phone number")
 	}
 
-	if c.Provider != "" && ( c.Number == "" || c.CountryCode == "" ){
+	if c.Provider != "" && (c.Number == "" || c.CountryCode == "") {
 		return fmt.Errorf("you must provide CountryCode and Number if Provider is provided")
 	}
 
@@ -101,7 +101,7 @@ func (c *Contact) PostContactParams() map[string]string {
 
 func (u *User) PutParams() map[string]string {
 	m := map[string]string{
-		"name" : u.Username,
+		"name": u.Username,
 	}
 
 	if u.Primary != "" {
@@ -119,4 +119,3 @@ func (u *User) PutParams() map[string]string {
 func (c *Contact) PutContactParams() map[string]string {
 	return c.PostContactParams()
 }
-

--- a/pingdom/user_types_test.go
+++ b/pingdom/user_types_test.go
@@ -1,16 +1,17 @@
 package pingdom
 
 import (
-	"github.com/stretchr/testify/assert"
-	"testing"
 	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUser_PostParams(t *testing.T) {
 	name := "testUsername"
 
 	user := User{
-		Username : name,
+		Username: name,
 	}
 	params := user.PostParams()
 	want := map[string]string{
@@ -23,7 +24,7 @@ func TestUser_PostParams(t *testing.T) {
 func TestUser_ValidUser_Positive(t *testing.T) {
 	name := "testUsername"
 	user := User{
-		Username : name,
+		Username: name,
 	}
 
 	err := user.ValidUser()
@@ -33,7 +34,7 @@ func TestUser_ValidUser_Positive(t *testing.T) {
 
 func TestUser_ValidUser_Negative(t *testing.T) {
 	user := User{
-		Username : "",
+		Username: "",
 	}
 
 	want := fmt.Errorf("Invalid value for `Username`.  Must contain non-empty string")
@@ -45,9 +46,9 @@ func TestUser_ValidUser_Negative(t *testing.T) {
 
 func TestContact_ValidContact_Positive1(t *testing.T) {
 	contact := Contact{
-		Email: "test@example.com",
+		Email:       "test@example.com",
 		CountryCode: "1",
-		Number: "5559995555",
+		Number:      "5559995555",
 	}
 
 	err := contact.ValidContact()
@@ -66,13 +67,12 @@ func TestContact_ValidContact_Positive2(t *testing.T) {
 func TestContact_ValidContact_Positive3(t *testing.T) {
 	contact := Contact{
 		CountryCode: "1",
-		Number: "5559995555",
+		Number:      "5559995555",
 	}
 
 	err := contact.ValidContact()
 	assert.Equal(t, nil, err, "contact.ValidContact() should return nil")
 }
-
 
 func TestContact_ValidContact_Negative1(t *testing.T) {
 	contact := Contact{
@@ -104,15 +104,15 @@ func TestContact_PostContactParams(t *testing.T) {
 	number := "5559995555"
 
 	contact := Contact{
-		Email: email,
+		Email:       email,
 		CountryCode: countrycode,
-		Number: number,
+		Number:      number,
 	}
 	params := contact.PostContactParams()
 	want := map[string]string{
-		"email" : email,
-		"number" : number,
-		"countrycode" : countrycode,
+		"email":       email,
+		"number":      number,
+		"countrycode": countrycode,
 	}
 
 	assert.Equal(t, want, params, "Contact.PostContactParams() should return correct map")
@@ -124,15 +124,15 @@ func TestContact_PutContactParams(t *testing.T) {
 	number := "5559995555"
 
 	contact := Contact{
-		Email: email,
+		Email:       email,
 		CountryCode: countrycode,
-		Number: number,
+		Number:      number,
 	}
 	params := contact.PutContactParams()
 	want := map[string]string{
-		"email" : email,
-		"number" : number,
-		"countrycode" : countrycode,
+		"email":       email,
+		"number":      number,
+		"countrycode": countrycode,
 	}
 
 	assert.Equal(t, want, params, "Contact.PutContactParams() should return correct map")
@@ -145,15 +145,15 @@ func TestUser_PutParams(t *testing.T) {
 
 	user := User{
 		Username: name,
-		Primary: primary,
-		Paused: paused,
+		Primary:  primary,
+		Paused:   paused,
 	}
 
 	params := user.PutParams()
 	want := map[string]string{
-		"name" : name,
-		"primary" : primary,
-		"paused" : paused,
+		"name":    name,
+		"primary": primary,
+		"paused":  paused,
 	}
 
 	assert.Equal(t, want, params, "User.PutParams() should return correct map")


### PR DESCRIPTION
There are three issues with the current parsing of teams as part of
a check instance response:

- the client must provide `?include_teams=true` to receive teams in
the API response
- the team response has the key "teams" not "teamids"
- the team response is a list of structs with "name" and "id" fields,
not a list of integers.

Unfortunately Pingdom returns "id" in a GET to the /teams list as
a string, but returns it as an integer in a GET to /checks, so we
create a separate struct for team responses as part of the check
response. Update the tests to handle this case.

We could add an optional parameter to ask callers whether they'd like
to include teams as part of the response, but it seems cheap enough to
always include them, and adding an option in the function interface
would probably be a breaking API change.

This work was sponsored by [Notion](https://www.notion.so).

Updates russellcardullo/terraform-provider-pingdom#26.