### PR TITLE
Add NewClientWithConfig method

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,41 @@ Pingdom handles single-user and multi-user accounts differently.
 Construct a new single-user Pingdom client:
 
 ```go
-client := pingdom.NewClient("pingdom_username", "pingdom_password", "pingdom_api_key")
+client, err := pingdom.NewClientWithConfig(pingdom.ClientConfig{
+    Username: "pingdom_username",
+    Password: "pingdom_password",
+    APIKey: "pingdom_api_key",
+})
 ```
 
 Construct a multi-user Pingdom client:
 
 ```go
-client := pingdom.NewMultiUserClient("pingdom_username", "pingdom_password", "pingdom_api_key", "pingdom_account_email")
+client, err := pingdom.NewClientWithConfig(pingdom.ClientConfig{
+    Username: "pingdom_username",
+    Password: "pingdom_password",
+    APIKey: "pingdom_api_key",
+    AccountEmail: "pingdom_account_email",
+})
 ```
 
 The `pingdom_account_email` variable is the email address of the owner of the multi-user account. This is passed in the `Account-Email` header to the Pingdom API.
 
 Using a Pingdom client, you can access supported services.
+
+You can override the timeout or other parameters by passing a custom http client:
+```go
+client, err := pingdom.NewClientWithConfig(pingdom.ClientConfig{
+    Username: "pingdom_username",
+    Password: "pingdom_password",
+    APIKey: "pingdom_api_key",
+    AccountEmail: "pingdom_account_email",
+    HTTPClient: &http.Client{
+        Timeout: time.Second * 10,
+    },
+})
+```
+
 
 ### CheckService ###
 
@@ -117,10 +140,10 @@ Create a new Maintenance Window:
 
 ```go
 m := pingdom.MaintenanceWindow{
-		Description: "My Maintenance",
-		From:        1,
-		To:          1234567899,
-	}
+    Description: "My Maintenance",
+    From:        1,
+    To:          1234567899,
+}
 maintenance, err := client.Maintenances.Create(&m)
 fmt.Println("Created MaintenanceWindow:", maintenance) // {ID Description}
 ```
@@ -135,9 +158,9 @@ Update a maintenance: (Please note, that based on experience, you are allowed to
 
 ```go
 updatedMaintenance := pingdom.MaintenanceWindow{
-		Description: "My Maintenance",
-		To:          1234567999,
-	}
+    Description: "My Maintenance",
+    To:          1234567999,
+}
 msg, err := client.Maintenances.Update(12345, &updatedMaintenance)
 ```
 
@@ -155,11 +178,11 @@ After contacting Pingdom, the better approach would be to use update function an
 maintenance, _ := client.Maintenances.Read(12345)
 
 m := pingdom.MaintenanceWindow{
-		Description: maintenance.Description,
-		From:        maintenance.From,
-		To:          1,
-		EffectiveTo: 1,
-	}
+    Description: maintenance.Description,
+    From:        maintenance.From,
+    To:          1,
+    EffectiveTo: 1,
+}
 
 maintenanceUpdate, err := client.Maintenances.Update(12345, &m)
 ```
@@ -182,7 +205,7 @@ probes, err := client.Probes.List(params)
 fmt.Println("Probes:", probes) // [{ID Name} ...]
 
 for _, probe := range probes {
-  fmt.Println("Probe region:", probe.Region)  // Probe region: EU
+    fmt.Println("Probe region:", probe.Region)  // Probe region: EU
 }
 ```
 
@@ -206,7 +229,7 @@ Create a new Team:
 
 ```go
 t := pingdom.TeamData{
-		Name: "Team",
+    Name: "Team",
 }
 team, err := client.Teams.Create(&t)
 fmt.Println("Created Team:", team) // {ID Name Users}
@@ -223,7 +246,7 @@ Update a team:
 ```go
 modifyTeam := pingdom.TeamData{
     Name:    "New Name"
-		UserIDs: "123,678",
+    UserIDs: "123,678",
 }
 team, err := client.Teams.Update(12345, &modifyTeam)
 ```
@@ -287,9 +310,9 @@ userId, err := client.Users.Create(user)
 fmt.Println("New UserId: ", userId.Id)
 
 contact := Contact{
-	Number : "5555555555",
-	CountryCode : "1",
-	Provider : "Verizon",
+    Number : "5555555555",
+    CountryCode : "1",
+    Provider : "Verizon",
 }
 contactId, err := client.Users.CreateContact(userId.Id, contact)
 fmt.Println("New Contact Id: ", contactId.Id)
@@ -309,9 +332,9 @@ result, err := client.Users.Update(userId, user)
 fmt.Println("result.Message)
 
 contact := Contact{
-	Number : "5555555555",
-	CountryCode : "1",
-	Provider : "Verizon",
+    Number : "5555555555",
+    CountryCode : "1",
+    Provider : "Verizon",
 }
 result, err := client.Users.UpdateContact(userId, contactId, contact)
 fmt.Println(result.Message)

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -1,9 +1,11 @@
 package acceptance
 
 import (
+	"net/http"
 	"os"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/russellcardullo/go-pingdom/pingdom"
 	"github.com/stretchr/testify/assert"
@@ -17,11 +19,15 @@ func init() {
 	if os.Getenv("PINGDOM_ACCEPTANCE") == "1" {
 		runAcceptance = true
 
-		user := os.Getenv("PINGDOM_USER")
-		password := os.Getenv("PINGDOM_PASSWORD")
-		apiKey := os.Getenv("PINGDOM_API_KEY")
-
-		client = pingdom.NewClient(user, password, apiKey)
+		config := pingdom.ClientConfig{
+			User:     os.Getenv("PINGDOM_USER"),
+			Password: os.Getenv("PINGDOM_PASSWORD"),
+			APIKey:   os.Getenv("PINGDOM_API_KEY"),
+			HTTPClient: &http.Client{
+				Timeout: time.Second * 10,
+			},
+		}
+		client, _ = pingdom.NewClientWithConfig(config)
 	}
 }
 

--- a/examples/example.go
+++ b/examples/example.go
@@ -14,7 +14,7 @@ import (
 type Credentials struct {
 	User         string `json:"user"`
 	Password     string `json:"password"`
-	ApiKey       string `json:"apikey"`
+	APIKey       string `json:"apikey"`
 	AccountEmail string `json:"accountEmail"`
 }
 
@@ -53,7 +53,7 @@ func getConfig() Credentials {
 
 func userExamples() {
 	config := getConfig()
-	client := pingdom.NewMultiUserClient(config.User, config.Password, config.ApiKey, config.AccountEmail)
+	client := pingdom.NewMultiUserClient(config.User, config.Password, config.APIKey, config.AccountEmail)
 
 	//Create User
 	user := pingdom.User{
@@ -95,7 +95,15 @@ func userExamples() {
 }
 
 func main() {
-	client := pingdom.NewClient("username", "password", "api_key")
+	client, err := pingdom.NewClientWithConfig(pingdom.ClientConfig{
+		User:     "username",
+		Password: "password",
+		APIKey:   "api_key",
+	})
+	if err != nil {
+		fmt.Println("Error", err)
+		os.Exit(1)
+	}
 
 	// List all checks
 	checks, _ := client.Checks.List()

--- a/pingdom/doc.go
+++ b/pingdom/doc.go
@@ -4,7 +4,11 @@ supports working with basic HTTP and ping checks.
 
 Construct a new Pingdom client:
 
-	client := pingdom.NewClient("pingdom_username", "pingdom_password", "pingdom_api_key")
+	client, err := pingdom.NewClientWithConfig(pingdom.ClientConfig{
+		Username: "pingdom_username",
+		Password: "pingdom_password",
+		APIKey: "pingdom_api_key",
+	})
 
 Using a Pingdom client, you can access supported services.
 

--- a/pingdom/pingdom_test.go
+++ b/pingdom/pingdom_test.go
@@ -24,7 +24,12 @@ func setup() {
 	server = httptest.NewServer(mux)
 
 	// test client
-	client = NewClient("fake_email@example.com", "12345", "my_api_key")
+	client, _ = NewClientWithConfig(ClientConfig{
+		User:     "fake_email@example.com",
+		Password: "12345",
+		APIKey:   "my_api_key",
+	})
+
 	url, _ := url.Parse(server.URL)
 	client.BaseURL = url
 }
@@ -35,6 +40,18 @@ func teardown() {
 
 func testMethod(t *testing.T, r *http.Request, want string) {
 	assert.Equal(t, want, r.Method)
+}
+
+func TestNewClientWithConfig(t *testing.T) {
+	c, err := NewClientWithConfig(ClientConfig{
+		User:     "user",
+		Password: "password",
+		APIKey:   "key",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, http.DefaultClient, c.client)
+	assert.Equal(t, defaultBaseURL, c.BaseURL.String())
+	assert.NotNil(t, c.Checks)
 }
 
 func TestNewClient(t *testing.T) {


### PR DESCRIPTION
Adds NewClientWithConfig method which allows more customization
of the Pingdom client used, such as supplying a custom http client
with different timeout setting.

This replaces the existing NewClient and NewMultiUserClient method.
Those methods are rewritten to call the new method and marked
as deprecated.

Closes #35.