### PR TITLE
Unmarshal check severity_level

### DIFF
--- a/pingdom/api_responses.go
+++ b/pingdom/api_responses.go
@@ -33,6 +33,7 @@ type CheckResponse struct {
 	LastResponseTime         int64               `json:"lastresponsetime,omitempty"`
 	Paused                   bool                `json:"paused,omitempty"`
 	IntegrationIds           []int               `json:"integrationids,omitempty"`
+	SeverityLevel            string              `json:"severity_level,omitempty"`
 	Type                     CheckResponseType   `json:"type,omitempty"`
 	Tags                     []CheckResponseTag  `json:"tags,omitempty"`
 	UserIds                  []int               `json:"userids,omitempty"`

--- a/pingdom/api_responses_test.go
+++ b/pingdom/api_responses_test.go
@@ -28,6 +28,7 @@ var detailedCheckJSON = `
 	},
 	"hostname" : "s7.mydomain.com",
 	"status" : "up",
+	"severity_level": "HIGH",
 	"lasterrortime" : 1293143467,
 	"lasttesttime" : 1294064823,
 	"tags": [],
@@ -48,4 +49,5 @@ func TestCheckResponseUnmarshal(t *testing.T) {
 	assert.Equal(t, "http", ck.Type.Name)
 	assert.NotNil(t, ck.Type.HTTP)
 	assert.Equal(t, 2, len(ck.Type.HTTP.RequestHeaders))
+	assert.Equal(t, "HIGH", ck.SeverityLevel)
 }


### PR DESCRIPTION
The Pingdom API allows an optional parameter when getting checks: `include_severity`.
This returns a `severity_level` field for each check: `HIGH` or `LOW`.

This can be changed in the Pingdom UI using a radio button: `Check Importance` which defaults to `High Severity`. 

There doesn't seem to be an equivalent parameter for check creation.