### PR TITLE
Re-implement Contacts and Teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,69 @@ Delete a team:
 team, err := client.Teams.Delete(12345)
 ```
 
+### ContactService ###
+
+This service manages users and their contact information which is represented by the `Contact` struct.
+More information from Pingdom: https://docs.pingdom.com/api/#tag/Contacts
+
+Get all contact info:
+
+```go
+contacts, err := client.Contacts.List()
+fmt.Println(contacts)
+```
+
+Create a new contact:
+
+```go
+contact := Contact{
+    Name: "John Doe",
+    Paused: false,
+    NotificationTargets: NotificationTargets{
+        SMS: []SMSNotificationTarget{
+            {
+                Number: "5555555555",
+                CountryCode: "1",
+                Provider: "Verizon",
+            }
+        }
+    }
+}
+contactId, err := client.Contacts.Create(contact)
+fmt.Println("New Contact ID: ", contactId.Id)
+```
+
+Update a contact
+
+```go
+contactId := 1234
+
+contact := Contact{
+    Name : "John Doe",
+    Paused : false,
+    NotificationTargets: NotificationTargets{
+        SMS: []SMSNotificationTarget{
+            {
+                Number: "5555555555",
+                CountryCode: "1",
+                Provider: "T-Mobile",
+            }
+        }
+    }
+}
+result, err := client.Contacts.Update(contactId, contact)
+fmt.Println(result.Message)
+```
+
+Delete a contact
+
+```go
+contactId := 1234
+
+result, err := client.Contacts.Delete(contactId)
+fmt.Println(result.Message)
+```
+
 ## Development ##
 
 ### Acceptance Tests ###

--- a/README.md
+++ b/README.md
@@ -188,6 +188,53 @@ for _, probe := range probes {
 }
 ```
 
+### TeamService ###
+
+This service manages pingdom Teams which are represented by the `Team` struct.
+When creating or updating Teams you must specify the `Name` and `MemberIDs`,
+though `MemberIDs` may be an empty slice.
+More information on Teams from Pingdom: https://docs.pingdom.com/api/#tag/Teams
+
+Get a list of all teams:
+
+```go
+teams, err := client.Teams.List()
+fmt.Println("Teams:", teams) // [{ID Name MemberIDs} ...]
+```
+
+Create a new Team:
+
+```go
+t := pingdom.TeamData{
+    Name: "Team",
+    MemberIDs: []int{},
+}
+team, err := client.Teams.Create(&t)
+fmt.Println("Created Team:", team) // {ID Name MemberIDs}
+```
+
+Get details for a specific team:
+
+```go
+team, err := client.Teams.Read(12345)
+```
+
+Update a team:
+
+```go
+modifyTeam := pingdom.TeamData{
+    Name:    "New Name"
+    MemberIDs: []int{123, 678},
+}
+team, err := client.Teams.Update(12345, &modifyTeam)
+```
+
+Delete a team:
+
+```go
+team, err := client.Teams.Delete(12345)
+```
+
 ## Development ##
 
 ### Acceptance Tests ###

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -106,3 +106,151 @@ func TestProbes(t *testing.T) {
 	assert.NotNil(t, probes)
 	assert.NotEmpty(t, probes)
 }
+
+func TestContacts(t *testing.T) {
+	if !runAcceptance {
+		t.Skip()
+	}
+
+	contact := pingdom.Contact{
+		Name:   "Test User",
+		Paused: false,
+		NotificationTargets: pingdom.NotificationTargets{
+			SMS: []pingdom.SMSNotification{
+				{
+					CountryCode: "00",
+					Number:      "5555555555",
+					Provider:    "nexmo",
+					Severity:    "LOW",
+				},
+				{
+					CountryCode: "00",
+					Number:      "5555555555",
+					Provider:    "nexmo",
+					Severity:    "HIGH",
+				},
+			},
+		},
+	}
+
+	createMsg, err := client.Contacts.Create(&contact)
+	assert.NoError(t, err)
+	assert.NotNil(t, createMsg)
+	assert.NotEmpty(t, createMsg)
+
+	contact.ID = createMsg.ID
+
+	listMsg, err := client.Contacts.List()
+	assert.NoError(t, err)
+	assert.NotNil(t, listMsg)
+	assert.NotEmpty(t, listMsg)
+
+	contact.NotificationTargets.SMS[0].Number = "2222222222"
+	updateMsg, err := client.Contacts.Update(contact.ID, &contact)
+	assert.NoError(t, err)
+	assert.NotNil(t, updateMsg)
+
+	delMsg, err := client.Contacts.Delete(contact.ID)
+	assert.NoError(t, err)
+	assert.NotNil(t, delMsg)
+}
+
+func TestTeams(t *testing.T) {
+	if !runAcceptance {
+		t.Skip()
+	}
+
+	team := pingdom.Team{
+		Name:      "Test team",
+		MemberIDs: []int{},
+	}
+
+	createMsg, err := client.Teams.Create(&team)
+	assert.NoError(t, err)
+	assert.NotNil(t, createMsg)
+	assert.NotEmpty(t, createMsg)
+
+	team.ID = createMsg.ID
+
+	listMsg, err := client.Teams.List()
+	assert.NoError(t, err)
+	assert.NotNil(t, listMsg)
+	assert.NotEmpty(t, listMsg)
+
+	team.Name = "Test team renamed"
+	updateMsg, err := client.Teams.Update(team.ID, &team)
+	assert.NoError(t, err)
+	assert.NotNil(t, updateMsg)
+	assert.NotEmpty(t, updateMsg)
+
+	delMsg, err := client.Teams.Delete(team.ID)
+	assert.NoError(t, err)
+	assert.NotNil(t, delMsg)
+}
+
+func TestTeamAndContactConnections(t *testing.T) {
+	if !runAcceptance {
+		t.Skip()
+	}
+
+	contact := pingdom.Contact{
+		Name:   "Test User",
+		Paused: false,
+		NotificationTargets: pingdom.NotificationTargets{
+			SMS: []pingdom.SMSNotification{
+				{
+					CountryCode: "00",
+					Number:      "5555555555",
+					Provider:    "nexmo",
+					Severity:    "LOW",
+				},
+				{
+					CountryCode: "00",
+					Number:      "5555555555",
+					Provider:    "nexmo",
+					Severity:    "HIGH",
+				},
+			},
+		},
+	}
+
+	team := pingdom.Team{
+		Name:      "Test team",
+		MemberIDs: []int{},
+	}
+
+	createTeamMsg, err := client.Teams.Create(&team)
+	assert.NoError(t, err)
+	assert.NotNil(t, createTeamMsg)
+	assert.NotEmpty(t, createTeamMsg)
+
+	team.ID = createTeamMsg.ID
+
+	createContactMsg, err := client.Contacts.Create(&contact)
+	assert.NoError(t, err)
+	assert.NotNil(t, createContactMsg)
+	assert.NotEmpty(t, createContactMsg)
+
+	contact.ID = createContactMsg.ID
+
+	team.MemberIDs = append(team.MemberIDs, contact.ID)
+
+	// Verify we can add contacts
+	updateMsg, err := client.Teams.Update(team.ID, &team)
+	assert.NoError(t, err)
+	assert.NotNil(t, updateMsg)
+	assert.NotEmpty(t, updateMsg)
+	assert.NotEmpty(t, updateMsg.Members)
+
+	team.MemberIDs = []int{}
+	// Verify we can remove contacts
+	updateMsg, err = client.Teams.Update(team.ID, &team)
+	assert.NoError(t, err)
+	assert.NotNil(t, updateMsg)
+	assert.NotEmpty(t, updateMsg)
+	assert.Empty(t, updateMsg.Members)
+
+	delMsg, err := client.Teams.Delete(team.ID)
+	assert.NoError(t, err)
+	assert.NotNil(t, delMsg)
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,5 @@ go 1.13
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.2.2
+	github.com/stretchr/testify v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
-github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/pingdom/api_responses.go
+++ b/pingdom/api_responses.go
@@ -119,6 +119,58 @@ type TeamDeleteResponse struct {
 	Message string `json:"message"`
 }
 
+// ContactResponse respresents the JSON response for alerting contacts from the Pingdom API
+type ContactResponse struct {
+	ID                  int                         `json:"id"`
+	Name                string                      `json:"name"`
+	NotificationTargets NotificationTargetsResponse `json:"notification_targets"`
+	Owner               bool                        `json:"owner"`
+	Paused              bool                        `json:"paused"`
+	Teams               []ContactTeamResponse       `json:"teams"`
+	Type                string                      `json:"type"`
+}
+
+// ContactTeamResponse represents the JSON response for teams a contact belongs to from the Pingdom API.
+type ContactTeamResponse struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// NotificationTargetsResponse represents the JSON response for notification phone numbers from the Pingdom API.
+type NotificationTargetsResponse struct {
+	SMS   []SMSNotificationResponse   `json:"sms,omitempty"`
+	Email []EmailNotificationResponse `json:"email,omitempty"`
+	APNS  []APNSNotificationResponse  `json:"apns,omitempty"`
+	AGCM  []AGCMNotificationResponse  `json:"agcm,omitempty"`
+}
+
+// SMSNotificationResponse represents an SMS notification attached to a contact
+type SMSNotificationResponse struct {
+	CountryCode string `json:"country_code"`
+	Number      string `json:"number"`
+	Provider    string `json:"provider"`
+	Severity    string `json:"severity"`
+}
+
+// EmailNotificationResponse represents an Email notification attached to a contact
+type EmailNotificationResponse struct {
+	Address  string `json:"address"`
+	Severity string `json:"severity"`
+}
+
+// APNSNotificationResponse represents an APNS notification attached to a contact
+type APNSNotificationResponse struct {
+	Device   string `json:"apns_device"`
+	Name     string `json:"device_name"`
+	Severity string `json:"severity"`
+}
+
+// AGCMNotificationResponse represents an AGCM notification attached to a contact
+type AGCMNotificationResponse struct {
+	AGCMID   string `json:"agcm_id"`
+	Severity string `json:"severity"`
+}
+
 // SummaryPerformanceResponse represents the JSON response for a summary performance from the Pingdom API.
 type SummaryPerformanceResponse struct {
 	Summary SummaryPerformanceMap `json:"summary"`
@@ -154,36 +206,6 @@ type Result struct {
 	ResponseTime   int    `json:"responsetime"`
 	StatusDesc     string `json:"statusdesc"`
 	StatusDescLong string `json:"statusdesclong"`
-}
-
-// UserSmsResponse represents the JSON response for a user SMS contact.
-type UserSmsResponse struct {
-	Id          int    `json:"id"`
-	Severity    string `json:"severity"`
-	CountryCode string `json:"country_code"`
-	Number      string `json:"number"`
-	Provider    string `json:"provider"`
-}
-
-// UserEmailResponse represents the JSON response for a user email contact.
-type UserEmailResponse struct {
-	Id       int    `json:"id"`
-	Severity string `json:"severity"`
-	Address  string `json:"address"`
-}
-
-// CreateUserContactResponse represents the JSON response for a user contact.
-type CreateUserContactResponse struct {
-	Id int `json:"id"`
-}
-
-// UsersResponse represents the JSON response for a Pingom User.
-type UsersResponse struct {
-	Id       int                 `json:"id"`
-	Paused   string              `json:"paused,omitempty"`
-	Username string              `json:"name,omitempty"`
-	Sms      []UserSmsResponse   `json:"sms,omitempty"`
-	Email    []UserEmailResponse `json:"email,omitempty"`
 }
 
 // UnmarshalJSON converts a byte array into a CheckResponseType.
@@ -270,6 +292,10 @@ type teamDetailsJSONResponse struct {
 	Team *TeamResponse `json:"team"`
 }
 
+type contactDetailsJSONResponse struct {
+	Contact *ContactResponse `json:"contact"`
+}
+
 type checkDetailsJSONResponse struct {
 	Check *CheckResponse `json:"check"`
 }
@@ -278,16 +304,12 @@ type maintenanceDetailsJSONResponse struct {
 	Maintenance *MaintenanceResponse `json:"maintenance"`
 }
 
-type createUserContactJSONResponse struct {
-	Contact *CreateUserContactResponse `json:"contact_target"`
+type createContactJSONResponse struct {
+	Contact *ContactResponse `json:"contact"`
 }
 
-type createUserJSONResponse struct {
-	User *UsersResponse `json:"user"`
-}
-
-type listUsersJSONResponse struct {
-	Users []UsersResponse `json:"users"`
+type listContactsJSONResponse struct {
+	Contacts []ContactResponse `json:"contacts"`
 }
 
 type errorJSONResponse struct {

--- a/pingdom/api_responses.go
+++ b/pingdom/api_responses.go
@@ -100,6 +100,25 @@ type ProbeResponse struct {
 	Region     string `json:"region"`
 }
 
+// TeamResponse represents the JSON response for alerting teams from the Pingdom API.
+type TeamResponse struct {
+	ID      int                  `json:"id"`
+	Name    string               `json:"name,omitempty"`
+	Members []TeamMemberResponse `json:"members,omitempty"`
+}
+
+// TeamMemberResponse represents the JSON response for contacts in alerting teams from the Pingdom API.
+type TeamMemberResponse struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+// TeamDeleteResponse represents the JSON response for delete team from the Pingdom API.
+type TeamDeleteResponse struct {
+	Message string `json:"message"`
+}
+
 // SummaryPerformanceResponse represents the JSON response for a summary performance from the Pingdom API.
 type SummaryPerformanceResponse struct {
 	Summary SummaryPerformanceMap `json:"summary"`
@@ -241,6 +260,14 @@ type listMaintenanceJSONResponse struct {
 
 type listProbesJSONResponse struct {
 	Probes []ProbeResponse `json:"probes"`
+}
+
+type listTeamsJSONResponse struct {
+	Teams []TeamResponse `json:"teams"`
+}
+
+type teamDetailsJSONResponse struct {
+	Team *TeamResponse `json:"team"`
 }
 
 type checkDetailsJSONResponse struct {

--- a/pingdom/api_responses.go
+++ b/pingdom/api_responses.go
@@ -119,58 +119,6 @@ type TeamDeleteResponse struct {
 	Message string `json:"message"`
 }
 
-// ContactResponse respresents the JSON response for alerting contacts from the Pingdom API
-type ContactResponse struct {
-	ID                  int                         `json:"id"`
-	Name                string                      `json:"name"`
-	NotificationTargets NotificationTargetsResponse `json:"notification_targets"`
-	Owner               bool                        `json:"owner"`
-	Paused              bool                        `json:"paused"`
-	Teams               []ContactTeamResponse       `json:"teams"`
-	Type                string                      `json:"type"`
-}
-
-// ContactTeamResponse represents the JSON response for teams a contact belongs to from the Pingdom API.
-type ContactTeamResponse struct {
-	ID   int    `json:"id"`
-	Name string `json:"name"`
-}
-
-// NotificationTargetsResponse represents the JSON response for notification phone numbers from the Pingdom API.
-type NotificationTargetsResponse struct {
-	SMS   []SMSNotificationResponse   `json:"sms,omitempty"`
-	Email []EmailNotificationResponse `json:"email,omitempty"`
-	APNS  []APNSNotificationResponse  `json:"apns,omitempty"`
-	AGCM  []AGCMNotificationResponse  `json:"agcm,omitempty"`
-}
-
-// SMSNotificationResponse represents an SMS notification attached to a contact
-type SMSNotificationResponse struct {
-	CountryCode string `json:"country_code"`
-	Number      string `json:"number"`
-	Provider    string `json:"provider"`
-	Severity    string `json:"severity"`
-}
-
-// EmailNotificationResponse represents an Email notification attached to a contact
-type EmailNotificationResponse struct {
-	Address  string `json:"address"`
-	Severity string `json:"severity"`
-}
-
-// APNSNotificationResponse represents an APNS notification attached to a contact
-type APNSNotificationResponse struct {
-	Device   string `json:"apns_device"`
-	Name     string `json:"device_name"`
-	Severity string `json:"severity"`
-}
-
-// AGCMNotificationResponse represents an AGCM notification attached to a contact
-type AGCMNotificationResponse struct {
-	AGCMID   string `json:"agcm_id"`
-	Severity string `json:"severity"`
-}
-
 // SummaryPerformanceResponse represents the JSON response for a summary performance from the Pingdom API.
 type SummaryPerformanceResponse struct {
 	Summary SummaryPerformanceMap `json:"summary"`
@@ -293,7 +241,7 @@ type teamDetailsJSONResponse struct {
 }
 
 type contactDetailsJSONResponse struct {
-	Contact *ContactResponse `json:"contact"`
+	Contact *Contact `json:"contact"`
 }
 
 type checkDetailsJSONResponse struct {
@@ -305,11 +253,11 @@ type maintenanceDetailsJSONResponse struct {
 }
 
 type createContactJSONResponse struct {
-	Contact *ContactResponse `json:"contact"`
+	Contact *Contact `json:"contact"`
 }
 
 type listContactsJSONResponse struct {
-	Contacts []ContactResponse `json:"contacts"`
+	Contacts []Contact `json:"contacts"`
 }
 
 type errorJSONResponse struct {

--- a/pingdom/api_responses_test.go
+++ b/pingdom/api_responses_test.go
@@ -111,22 +111,22 @@ var detailedContactJSON = `
 }
 `
 
-func TestCheckContactResponseUnmarshal(t *testing.T) {
+func TestCheckContactUnmarshal(t *testing.T) {
 	var contacts listContactsJSONResponse
 	err := json.Unmarshal([]byte(detailedContactJSON), &contacts)
 	contact := contacts.Contacts[0]
 
-	expectedNotificationTargets := NotificationTargetsResponse{
-		SMS: []SMSNotificationResponse{
-			SMSNotificationResponse{
+	expectedNotificationTargets := NotificationTargets{
+		SMS: []SMSNotification{
+			SMSNotification{
 				Severity:    "HIGH",
 				CountryCode: "00",
 				Number:      "111111111",
 				Provider:    "provider's name",
 			},
 		},
-		Email: []EmailNotificationResponse{
-			EmailNotificationResponse{
+		Email: []EmailNotification{
+			EmailNotification{
 				Severity: "HIGH",
 				Address:  "johndoe@teamrocket.com",
 			},

--- a/pingdom/api_responses_test.go
+++ b/pingdom/api_responses_test.go
@@ -51,3 +51,89 @@ func TestCheckResponseUnmarshal(t *testing.T) {
 	assert.Equal(t, 2, len(ck.Type.HTTP.RequestHeaders))
 	assert.Equal(t, "HIGH", ck.SeverityLevel)
 }
+
+var detailedContactJSON = `
+{
+	"contacts": [
+		{
+			"id": 1,
+			"name": "John Doe",
+			"paused": false,
+			"type": "user",
+			"owner": true,
+			"notification_targets": {
+				"email": [
+					{
+					"severity": "HIGH",
+					"address": "johndoe@teamrocket.com"
+					}
+				],
+				"sms": [
+					{
+					"severity": "HIGH",
+					"country_code": "00",
+					"number": "111111111",
+					"provider": "provider's name"
+					}
+				]
+			},
+			"teams": [
+				{
+					"id": 123456,
+					"name": "The Dream Team"
+				}
+			]
+		},
+		{
+			"id": 2,
+			"name": "John \"Hannibal\" Smith",
+			"paused": true,
+			"type": "user",
+			"notification_targets": {
+			"email": [
+				{
+				"severity": "HIGH",
+				"address": "hannibal@ateam.org"
+				}
+			],
+			"sms": [
+				{
+				"severity": "HIGH",
+				"country_code": "00",
+				"number": "222222222",
+				"provider": "provider's name"
+				}
+			]
+			},
+			"teams": []
+		}
+	]
+}
+`
+
+func TestCheckContactResponseUnmarshal(t *testing.T) {
+	var contacts listContactsJSONResponse
+	err := json.Unmarshal([]byte(detailedContactJSON), &contacts)
+	contact := contacts.Contacts[0]
+
+	expectedNotificationTargets := NotificationTargetsResponse{
+		SMS: []SMSNotificationResponse{
+			SMSNotificationResponse{
+				Severity:    "HIGH",
+				CountryCode: "00",
+				Number:      "111111111",
+				Provider:    "provider's name",
+			},
+		},
+		Email: []EmailNotificationResponse{
+			EmailNotificationResponse{
+				Severity: "HIGH",
+				Address:  "johndoe@teamrocket.com",
+			},
+		},
+	}
+	assert.NoError(t, err)
+	assert.Equal(t, "John Doe", contact.Name)
+	assert.NotNil(t, contact.ID)
+	assert.Equal(t, expectedNotificationTargets, contact.NotificationTargets)
+}

--- a/pingdom/contact.go
+++ b/pingdom/contact.go
@@ -19,7 +19,7 @@ type ContactAPI interface {
 }
 
 // List returns a list of all contacts and their contact details.
-func (cs *ContactService) List() ([]ContactResponse, error) {
+func (cs *ContactService) List() ([]Contact, error) {
 
 	req, err := cs.client.NewRequest("GET", "/alerting/contacts", nil)
 	if err != nil {
@@ -46,7 +46,7 @@ func (cs *ContactService) List() ([]ContactResponse, error) {
 }
 
 // Read return a contact object from Pingdom.
-func (cs *ContactService) Read(contactID int) (*ContactResponse, error) {
+func (cs *ContactService) Read(contactID int) (*Contact, error) {
 	req, err := cs.client.NewRequest("GET", "/alerting/contacts/"+strconv.Itoa(contactID), nil)
 	if err != nil {
 		return nil, err
@@ -62,7 +62,7 @@ func (cs *ContactService) Read(contactID int) (*ContactResponse, error) {
 }
 
 // Create adds a new contact.
-func (cs *ContactService) Create(contact ContactAPI) (*ContactResponse, error) {
+func (cs *ContactService) Create(contact ContactAPI) (*Contact, error) {
 	if err := contact.ValidContact(); err != nil {
 		return nil, err
 	}

--- a/pingdom/contact.go
+++ b/pingdom/contact.go
@@ -1,0 +1,116 @@
+package pingdom
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"strconv"
+)
+
+// ContactService provides an interface to Pingdom contacts.
+type ContactService struct {
+	client *Client
+}
+
+// ContactAPI is an interface representing a Pingdom Contact.
+type ContactAPI interface {
+	RenderForJSONAPI() string
+	ValidContact() error
+}
+
+// List returns a list of all contacts and their contact details.
+func (cs *ContactService) List() ([]ContactResponse, error) {
+
+	req, err := cs.client.NewRequest("GET", "/alerting/contacts", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := cs.client.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if err := validateResponse(resp); err != nil {
+		return nil, err
+	}
+
+	bodyBytes, _ := ioutil.ReadAll(resp.Body)
+	bodyString := string(bodyBytes)
+
+	u := &listContactsJSONResponse{}
+	err = json.Unmarshal([]byte(bodyString), &u)
+
+	return u.Contacts, err
+}
+
+// Read return a contact object from Pingdom.
+func (cs *ContactService) Read(contactID int) (*ContactResponse, error) {
+	req, err := cs.client.NewRequest("GET", "/alerting/contacts/"+strconv.Itoa(contactID), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &contactDetailsJSONResponse{}
+	_, err = cs.client.Do(req, c)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.Contact, nil
+}
+
+// Create adds a new contact.
+func (cs *ContactService) Create(contact ContactAPI) (*ContactResponse, error) {
+	if err := contact.ValidContact(); err != nil {
+		return nil, err
+	}
+
+	req, err := cs.client.NewJSONRequest("POST", "/alerting/contacts", contact.RenderForJSONAPI())
+	if err != nil {
+		return nil, err
+	}
+
+	m := &createContactJSONResponse{}
+	_, err = cs.client.Do(req, m)
+	if err != nil {
+		fmt.Println(err)
+		return nil, err
+	}
+	return m.Contact, err
+}
+
+// Update a contact's core properties not contact targets.
+func (cs *ContactService) Update(id int, contact ContactAPI) (*PingdomResponse, error) {
+	if err := contact.ValidContact(); err != nil {
+		return nil, err
+	}
+
+	req, err := cs.client.NewJSONRequest("PUT", "/alerting/contacts/"+strconv.Itoa(id), contact.RenderForJSONAPI())
+	if err != nil {
+		return nil, err
+	}
+
+	m := &PingdomResponse{}
+	_, err = cs.client.Do(req, m)
+	if err != nil {
+		return nil, err
+	}
+	return m, err
+}
+
+// Delete removes a contact from Pingdom.
+func (cs *ContactService) Delete(id int) (*PingdomResponse, error) {
+	req, err := cs.client.NewRequest("DELETE", "/alerting/contacts/"+strconv.Itoa(id), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	m := &PingdomResponse{}
+	_, err = cs.client.Do(req, m)
+	if err != nil {
+		return nil, err
+	}
+	return m, err
+}

--- a/pingdom/contact_test.go
+++ b/pingdom/contact_test.go
@@ -72,21 +72,21 @@ func TestContactService_List(t *testing.T) {
 			]
 		}`)
 	})
-	want := []ContactResponse{
+	want := []Contact{
 		{
 			ID:     1,
 			Paused: false,
 			Name:   "John Doe",
 			Owner:  true,
-			Teams: []ContactTeamResponse{
+			Teams: []ContactTeam{
 				{
 					ID:   123456,
 					Name: "The Dream Team",
 				},
 			},
 			Type: "user",
-			NotificationTargets: NotificationTargetsResponse{
-				SMS: []SMSNotificationResponse{
+			NotificationTargets: NotificationTargets{
+				SMS: []SMSNotification{
 					{
 						Severity:    "HIGH",
 						CountryCode: "00",
@@ -94,7 +94,7 @@ func TestContactService_List(t *testing.T) {
 						Provider:    "provider's name",
 					},
 				},
-				Email: []EmailNotificationResponse{
+				Email: []EmailNotification{
 					{
 						Severity: "HIGH",
 						Address:  "johndoe@teamrocket.com",
@@ -107,9 +107,9 @@ func TestContactService_List(t *testing.T) {
 			Paused: true,
 			Name:   "John \"Hannibal\" Smith",
 			Type:   "user",
-			Teams:  []ContactTeamResponse{},
-			NotificationTargets: NotificationTargetsResponse{
-				SMS: []SMSNotificationResponse{
+			Teams:  []ContactTeam{},
+			NotificationTargets: NotificationTargets{
+				SMS: []SMSNotification{
 					{
 						Severity:    "HIGH",
 						CountryCode: "00",
@@ -117,7 +117,7 @@ func TestContactService_List(t *testing.T) {
 						Provider:    "provider's name",
 					},
 				},
-				Email: []EmailNotificationResponse{
+				Email: []EmailNotification{
 					{
 						Severity: "HIGH",
 						Address:  "hannibal@ateam.org",
@@ -170,29 +170,29 @@ func TestContactService_Read(t *testing.T) {
 			}
 		  }`)
 	})
-	want := ContactResponse{
+	want := Contact{
 		ID:     123456,
 		Paused: false,
 		Name:   "John Doe",
 		Owner:  true,
 		Type:   "user",
-		NotificationTargets: NotificationTargetsResponse{
-			SMS: []SMSNotificationResponse{
-				SMSNotificationResponse{
+		NotificationTargets: NotificationTargets{
+			SMS: []SMSNotification{
+				SMSNotification{
 					Severity:    "HIGH",
 					CountryCode: "00",
 					Number:      "111111111",
 					Provider:    "provider's name",
 				},
 			},
-			Email: []EmailNotificationResponse{
+			Email: []EmailNotification{
 				{
 					Address:  "johndoe@teamrocket.com",
 					Severity: "HIGH",
 				},
 			},
 		},
-		Teams: []ContactTeamResponse{
+		Teams: []ContactTeam{
 			{
 				ID:   123456,
 				Name: "The Dream Team",
@@ -218,7 +218,7 @@ func TestContactService_Create(t *testing.T) {
 		}`)
 	})
 
-	want := &ContactResponse{
+	want := &Contact{
 		ID: 23439,
 	}
 

--- a/pingdom/contact_test.go
+++ b/pingdom/contact_test.go
@@ -1,0 +1,281 @@
+package pingdom
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContactService_List(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/alerting/contacts", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"contacts": [
+				{
+					"id": 1,
+					"name": "John Doe",
+					"paused": false,
+					"type": "user",
+					"owner": true,
+					"notification_targets": {
+						"email": [
+							{
+								"severity": "HIGH",
+								"address": "johndoe@teamrocket.com"
+							}
+						],
+						"sms": [
+							{
+								"severity": "HIGH",
+								"country_code": "00",
+								"number": "111111111",
+								"provider": "provider's name"
+							}
+						]
+					},
+					"teams": [
+						{
+							"id": 123456,
+							"name": "The Dream Team"
+						}
+					]
+				},
+				{
+					"id": 2,
+					"name": "John \"Hannibal\" Smith",
+					"paused": true,
+					"type": "user",
+					"notification_targets": {
+						"email": [
+							{
+								"severity": "HIGH",
+								"address": "hannibal@ateam.org"
+							}
+						],
+						"sms": [
+							{
+								"severity": "HIGH",
+								"country_code": "00",
+								"number": "222222222",
+								"provider": "provider's name"
+							}
+						]
+					},
+					"teams": []
+				}
+			]
+		}`)
+	})
+	want := []ContactResponse{
+		{
+			ID:     1,
+			Paused: false,
+			Name:   "John Doe",
+			Owner:  true,
+			Teams: []ContactTeamResponse{
+				{
+					ID:   123456,
+					Name: "The Dream Team",
+				},
+			},
+			Type: "user",
+			NotificationTargets: NotificationTargetsResponse{
+				SMS: []SMSNotificationResponse{
+					{
+						Severity:    "HIGH",
+						CountryCode: "00",
+						Number:      "111111111",
+						Provider:    "provider's name",
+					},
+				},
+				Email: []EmailNotificationResponse{
+					{
+						Severity: "HIGH",
+						Address:  "johndoe@teamrocket.com",
+					},
+				},
+			},
+		},
+		{
+			ID:     2,
+			Paused: true,
+			Name:   "John \"Hannibal\" Smith",
+			Type:   "user",
+			Teams:  []ContactTeamResponse{},
+			NotificationTargets: NotificationTargetsResponse{
+				SMS: []SMSNotificationResponse{
+					{
+						Severity:    "HIGH",
+						CountryCode: "00",
+						Number:      "222222222",
+						Provider:    "provider's name",
+					},
+				},
+				Email: []EmailNotificationResponse{
+					{
+						Severity: "HIGH",
+						Address:  "hannibal@ateam.org",
+					},
+				},
+			},
+		},
+	}
+
+	contacts, err := client.Contacts.List()
+	assert.NoError(t, err)
+	assert.Equal(t, want, contacts, "Contacts.List() should return correct result")
+}
+
+func TestContactService_Read(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/alerting/contacts/123456", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"contact": {
+				"id": 123456,
+				"name": "John Doe",
+				"paused": false,
+				"type": "user",
+				"owner": true,
+				"notification_targets": {
+					"email": [
+						{
+							"severity": "HIGH",
+							"address": "johndoe@teamrocket.com"
+						}
+					],
+					"sms": [
+						{
+							"severity": "HIGH",
+							"country_code": "00",
+							"number": "111111111",
+							"provider": "provider's name"
+						}
+					]
+				},
+				"teams": [
+					{
+						"id": 123456,
+						"name": "The Dream Team"
+					}
+				]
+			}
+		  }`)
+	})
+	want := ContactResponse{
+		ID:     123456,
+		Paused: false,
+		Name:   "John Doe",
+		Owner:  true,
+		Type:   "user",
+		NotificationTargets: NotificationTargetsResponse{
+			SMS: []SMSNotificationResponse{
+				SMSNotificationResponse{
+					Severity:    "HIGH",
+					CountryCode: "00",
+					Number:      "111111111",
+					Provider:    "provider's name",
+				},
+			},
+			Email: []EmailNotificationResponse{
+				{
+					Address:  "johndoe@teamrocket.com",
+					Severity: "HIGH",
+				},
+			},
+		},
+		Teams: []ContactTeamResponse{
+			{
+				ID:   123456,
+				Name: "The Dream Team",
+			},
+		},
+	}
+
+	contacts, err := client.Contacts.Read(123456)
+	assert.NoError(t, err)
+	assert.Equal(t, &want, contacts, "Contacts.Read(123456) should return a contact")
+}
+
+func TestContactService_Create(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/alerting/contacts", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		fmt.Fprint(w, `{
+			"contact": {
+				"id": 23439
+			}
+		}`)
+	})
+
+	want := &ContactResponse{
+		ID: 23439,
+	}
+
+	u := Contact{
+		Name: "testContact",
+	}
+
+	contact, err := client.Contacts.Create(&u)
+	assert.NoError(t, err)
+	assert.Equal(t, want, contact, "Contacts.Create() should return correct result")
+}
+
+func TestContactService_Delete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	contactID := 12941
+
+	mux.HandleFunc("/alerting/contacts/"+strconv.Itoa(contactID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		fmt.Fprint(w, `{
+			"message":"Deletion of contact was successful!"
+		}`)
+	})
+
+	want := &PingdomResponse{
+		Message: "Deletion of contact was successful!",
+	}
+
+	response, err := client.Contacts.Delete(contactID)
+	assert.NoError(t, err)
+	assert.Equal(t, want, response, "Contacts.Delete() should return PingdomResponse with message")
+
+}
+
+func TestContactService_Update(t *testing.T) {
+	setup()
+	defer teardown()
+
+	contactID := 12941
+	contact := Contact{
+		Name: "updatedName",
+	}
+
+	mux.HandleFunc("/alerting/contacts/"+strconv.Itoa(contactID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		fmt.Fprint(w, `{
+			"message":"Modification of contact was successful!"
+		}`)
+	})
+
+	want := &PingdomResponse{
+		Message: "Modification of contact was successful!",
+	}
+
+	response, err := client.Contacts.Update(contactID, &contact)
+	assert.NoError(t, err)
+	assert.Equal(t, want, response, "Contacts.Update() should return PingdomResponse with message")
+
+}

--- a/pingdom/contact_types.go
+++ b/pingdom/contact_types.go
@@ -5,20 +5,6 @@ import (
 	"fmt"
 )
 
-// UserSms represents the sms contact object for a User.
-type UserSms struct {
-	Severity    string `json:"severity"`
-	CountryCode string `json:"country_code"`
-	Number      string `json:"number"`
-	Provider    string `json:"provider"`
-}
-
-// UserEmail represents the email contact object for a User.
-type UserEmail struct {
-	Severity string `json:"severity"`
-	Address  string `json:"address"`
-}
-
 // NotificationTargets represents different ways a contact could be notified of alerts
 type NotificationTargets struct {
 	SMS   []SMSNotification   `json:"sms,omitempty"`
@@ -56,7 +42,7 @@ type AGCMNotification struct {
 
 // ContactTeam represents an alerting team from the view of a Contact
 type ContactTeam struct {
-	ID   string `json:"id"`
+	ID   int    `json:"id"`
 	Name string `json:"name"`
 }
 

--- a/pingdom/contact_types.go
+++ b/pingdom/contact_types.go
@@ -1,0 +1,92 @@
+package pingdom
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// UserSms represents the sms contact object for a User.
+type UserSms struct {
+	Severity    string `json:"severity"`
+	CountryCode string `json:"country_code"`
+	Number      string `json:"number"`
+	Provider    string `json:"provider"`
+}
+
+// UserEmail represents the email contact object for a User.
+type UserEmail struct {
+	Severity string `json:"severity"`
+	Address  string `json:"address"`
+}
+
+// NotificationTargets represents different ways a contact could be notified of alerts
+type NotificationTargets struct {
+	SMS   []SMSNotification   `json:"sms,omitempty"`
+	Email []EmailNotification `json:"email,omitempty"`
+	APNS  []APNSNotification  `json:"apns,omitempty"`
+	AGCM  []AGCMNotification  `json:"agcm,omitempty"`
+}
+
+// SMSNotification represents a text message notification
+type SMSNotification struct {
+	CountryCode string `json:"country_code"`
+	Number      string `json:"number"`
+	Provider    string `json:"provider"`
+	Severity    string `json:"severity"`
+}
+
+// EmailNotification represents an email address notification
+type EmailNotification struct {
+	Address  string `json:"address"`
+	Severity string `json:"severity"`
+}
+
+// APNSNotification represents an APNS device notification
+type APNSNotification struct {
+	Device   string `json:"apns_device"`
+	Name     string `json:"device_name"`
+	Severity string `json:"severity"`
+}
+
+// AGCMNotification represents an AGCM notification
+type AGCMNotification struct {
+	AGCMID   string `json:"agcm_id"`
+	Severity string `json:"severity"`
+}
+
+// ContactTeam represents an alerting team from the view of a Contact
+type ContactTeam struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// Contact represents a Pingdom Contact.
+type Contact struct {
+	ID                  int                 `json:"id"`
+	Name                string              `json:"name"`
+	NotificationTargets NotificationTargets `json:"notification_targets"`
+	Owner               bool                `json:"owner"`
+	Paused              bool                `json:"paused"`
+	Teams               []ContactTeam       `json:"teams"`
+	Type                string              `json:"type"`
+}
+
+// ValidContact determines whether a Contact contains valid fields.
+func (c *Contact) ValidContact() error {
+	if c.Name == "" {
+		return fmt.Errorf("Invalid value for `Name`.  Must contain non-empty string")
+	}
+
+	return nil
+}
+
+// RenderForJSONAPI returns the JSON formatted version of this object that may be submitted to Pingdom
+func (c *Contact) RenderForJSONAPI() string {
+	u := map[string]interface{}{
+		"name":                 c.Name,
+		"notification_targets": c.NotificationTargets,
+		"paused":               c.Paused,
+	}
+	jsonBody, _ := json.Marshal(u)
+	return string(jsonBody)
+}

--- a/pingdom/contact_types_test.go
+++ b/pingdom/contact_types_test.go
@@ -1,0 +1,31 @@
+package pingdom
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContact_ValidContact_Positive(t *testing.T) {
+	name := "testName"
+	contact := Contact{
+		Name: name,
+	}
+
+	err := contact.ValidContact()
+
+	assert.Equal(t, nil, err, "Contact.ValidContact() should return nil")
+}
+
+func TestContact_ValidContact_Negative(t *testing.T) {
+	contact := Contact{
+		Name: "",
+	}
+
+	want := fmt.Errorf("Invalid value for `Name`.  Must contain non-empty string")
+
+	err := contact.ValidContact()
+
+	assert.Equal(t, want, err, "Contact.ValidContact() should return error")
+}

--- a/pingdom/pingdom.go
+++ b/pingdom/pingdom.go
@@ -19,6 +19,7 @@ type Client struct {
 	BaseURL      *url.URL
 	client       *http.Client
 	Checks       *CheckService
+	Contacts     *ContactService
 	Maintenances *MaintenanceService
 	Probes       *ProbeService
 	Teams        *TeamService
@@ -56,6 +57,7 @@ func NewClientWithConfig(config ClientConfig) (*Client, error) {
 	}
 
 	c.Checks = &CheckService{client: c}
+	c.Contacts = &ContactService{client: c}
 	c.Maintenances = &MaintenanceService{client: c}
 	c.Probes = &ProbeService{client: c}
 	c.Teams = &TeamService{client: c}

--- a/pingdom/pingdom.go
+++ b/pingdom/pingdom.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 const (
@@ -20,6 +21,7 @@ type Client struct {
 	Checks       *CheckService
 	Maintenances *MaintenanceService
 	Probes       *ProbeService
+	Teams        *TeamService
 }
 
 // ClientConfig represents a configuration for a pingdom client.
@@ -56,6 +58,7 @@ func NewClientWithConfig(config ClientConfig) (*Client, error) {
 	c.Checks = &CheckService{client: c}
 	c.Maintenances = &MaintenanceService{client: c}
 	c.Probes = &ProbeService{client: c}
+	c.Teams = &TeamService{client: c}
 	return c, nil
 }
 
@@ -81,6 +84,23 @@ func (pc *Client) NewRequest(method string, rsc string, params map[string]string
 
 	req, err := http.NewRequest(method, baseURL.String(), nil)
 	req.Header.Add("Authorization", "Bearer "+pc.APIToken)
+	return req, err
+}
+
+// NewJSONRequest makes a new HTTP Request.  The method param should be an HTTP method in
+// all caps such as GET, POST, PUT, DELETE.  The rsc param should correspond with
+// a restful resource.  Params should be a json formatted string.
+func (pc *Client) NewJSONRequest(method string, rsc string, params string) (*http.Request, error) {
+	baseURL, err := url.Parse(pc.BaseURL.String() + rsc)
+	if err != nil {
+		return nil, err
+	}
+
+	reqBody := strings.NewReader(params)
+
+	req, err := http.NewRequest(method, baseURL.String(), reqBody)
+	req.Header.Add("Authorization", "Bearer "+pc.APIToken)
+	req.Header.Add("Content-Type", "application/json")
 	return req, err
 }
 

--- a/pingdom/team.go
+++ b/pingdom/team.go
@@ -1,0 +1,109 @@
+package pingdom
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"strconv"
+)
+
+// TeamService provides an interface to Pingdom teams.
+type TeamService struct {
+	client *Client
+}
+
+// TeamAPI is an interface representing a Pingdom team.
+type TeamAPI interface {
+	RenderForJSONAPI() string
+	Valid() error
+}
+
+// List return a list of teams from Pingdom.
+func (cs *TeamService) List() ([]TeamResponse, error) {
+	req, err := cs.client.NewRequest("GET", "/alerting/teams", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := cs.client.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if err := validateResponse(resp); err != nil {
+		return nil, err
+	}
+
+	bodyBytes, _ := ioutil.ReadAll(resp.Body)
+	bodyString := string(bodyBytes)
+
+	t := &listTeamsJSONResponse{}
+	err = json.Unmarshal([]byte(bodyString), &t)
+
+	return t.Teams, err
+}
+
+// Read return a team object from Pingdom.
+func (cs *TeamService) Read(id int) (*TeamResponse, error) {
+	req, err := cs.client.NewRequest("GET", "/alerting/teams/"+strconv.Itoa(id), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	t := &teamDetailsJSONResponse{}
+	_, err = cs.client.Do(req, t)
+	if err != nil {
+		return nil, err
+	}
+
+	return t.Team, err
+}
+
+// Create is used to create a new team.
+func (cs *TeamService) Create(team TeamAPI) (*TeamResponse, error) {
+	if err := team.Valid(); err != nil {
+		return nil, err
+	}
+
+	req, err := cs.client.NewJSONRequest("POST", "/alerting/teams", team.RenderForJSONAPI())
+	if err != nil {
+		return nil, err
+	}
+
+	t := &teamDetailsJSONResponse{}
+	_, err = cs.client.Do(req, t)
+	if err != nil {
+		return nil, err
+	}
+	return t.Team, err
+}
+
+// Update is used to update existing team.
+func (cs *TeamService) Update(id int, team TeamAPI) (*TeamResponse, error) {
+	req, err := cs.client.NewJSONRequest("PUT", "/alerting/teams/"+strconv.Itoa(id), team.RenderForJSONAPI())
+	if err != nil {
+		return nil, err
+	}
+
+	t := &teamDetailsJSONResponse{}
+	_, err = cs.client.Do(req, t)
+	if err != nil {
+		return nil, err
+	}
+	return t.Team, err
+}
+
+// Delete will delete the Team for the given ID.
+func (cs *TeamService) Delete(id int) (*TeamDeleteResponse, error) {
+	req, err := cs.client.NewRequest("DELETE", "/alerting/teams/"+strconv.Itoa(id), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	t := &TeamDeleteResponse{}
+	_, err = cs.client.Do(req, t)
+	if err != nil {
+		return nil, err
+	}
+	return t, err
+}

--- a/pingdom/team_test.go
+++ b/pingdom/team_test.go
@@ -1,0 +1,228 @@
+package pingdom
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMTeamServiceList(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/alerting/teams", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"teams": [
+			  	{
+					"id": 1,
+					"name": "Team Rocket",
+					"members": [
+						{
+							"id": 1,
+							"name": "John Doe",
+							"type": "user"
+						}
+					]
+				},
+				{
+					"id": 2,
+					"name": "The A-Team",
+					"members": [
+						{
+							"id": 2,
+							"name": "John 'Hannibal' Smith",
+							"type": "user"
+						},
+						{
+							"id": 3,
+							"name": "Templeton 'Faceman' Peck",
+							"type": "contact"
+						}
+					]
+				}
+			]
+		  }`,
+		)
+	})
+	want := []TeamResponse{
+		{
+			ID:   1,
+			Name: "Team Rocket",
+			Members: []TeamMemberResponse{
+				{
+					ID:   1,
+					Name: "John Doe",
+					Type: "user",
+				},
+			},
+		},
+		{
+			ID:   2,
+			Name: "The A-Team",
+			Members: []TeamMemberResponse{
+				{
+					ID:   2,
+					Name: "John 'Hannibal' Smith",
+					Type: "user",
+				},
+				{
+					ID:   3,
+					Name: "Templeton 'Faceman' Peck",
+					Type: "contact",
+				},
+			},
+		},
+	}
+
+	teams, err := client.Teams.List()
+	assert.NoError(t, err)
+	assert.Equal(t, want, teams, "Teams.List() should return correct result")
+}
+
+func TestTeamServiceCreate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/alerting/teams", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		fmt.Fprint(w, `{
+			"team": {
+			  	"id": 12345678
+			}
+		  }`)
+	})
+
+	team := Team{
+		Name:      "Operations",
+		MemberIDs: []int{12345, 54321},
+	}
+
+	want := &TeamResponse{
+		ID: 12345678,
+	}
+
+	teams, err := client.Teams.Create(&team)
+	assert.NoError(t, err)
+	assert.Equal(t, want, teams, "Teams.Create() should return correct result")
+}
+
+func TestTeamServiceRead(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/alerting/teams/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"team": {
+				"id": 1,
+				"name": "Team Rocket",
+				"members": [
+					{
+						"id": 1,
+						"name": "John Doe",
+						"type": "user"
+					},
+					{
+						"id": 4,
+						"name": "Sidekick Jimmy",
+						"type": "contact"
+					}
+				]
+			}
+		}`)
+	})
+
+	want := &TeamResponse{
+		ID:   1,
+		Name: "Team Rocket",
+		Members: []TeamMemberResponse{
+			{
+				ID:   1,
+				Name: "John Doe",
+				Type: "user",
+			},
+			{
+				ID:   4,
+				Name: "Sidekick Jimmy",
+				Type: "contact",
+			},
+		},
+	}
+
+	team, err := client.Teams.Read(1)
+	assert.NoError(t, err)
+	assert.Equal(t, want, team, "Teams.Read() should return correct result")
+}
+
+func TestTeamServiceUpdate(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/alerting/teams/65", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		fmt.Fprint(w, `{
+			"team": {
+				"id": 65,
+				"name": "Operations",
+				"members": [
+				{
+					"id": 10034512,
+					"name": "John \"Hannibal\" Smith",
+					"type": "contact"
+				},
+				{
+					"id": 10043154,
+					"name": "Templeton \"Face(man)\" Peck",
+					"type": "contact"
+				}
+				]
+			}
+		}`)
+	})
+
+	updateTeam := Team{
+		Name:      "Operations",
+		MemberIDs: []int{10034512, 10043154},
+	}
+
+	want := &TeamResponse{
+		ID:   65,
+		Name: "Operations",
+		Members: []TeamMemberResponse{
+			{
+				ID:   10034512,
+				Name: "John \"Hannibal\" Smith",
+				Type: "contact",
+			},
+			{
+				ID:   10043154,
+				Name: "Templeton \"Face(man)\" Peck",
+				Type: "contact",
+			},
+		},
+	}
+
+	team, err := client.Teams.Update(65, &updateTeam)
+	assert.NoError(t, err)
+	assert.Equal(t, want, team, "Teams.Update() should return correct result")
+}
+
+func TestTeamServiceDelete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/alerting/teams/1234", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		fmt.Fprint(w, `{
+			"message": "Deletion of team 1234 was successful"
+	}`)
+	})
+	want := &TeamDeleteResponse{Message: "Deletion of team 1234 was successful"}
+
+	team, err := client.Teams.Delete(1234)
+	assert.NoError(t, err)
+	assert.Equal(t, want, team, "Teams.Delete() should return correct result")
+}

--- a/pingdom/team_types.go
+++ b/pingdom/team_types.go
@@ -1,0 +1,33 @@
+package pingdom
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Team represents a Pingdom Team Data.
+type Team struct {
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	MemberIDs []int  `json:"member_ids,omitempty"`
+}
+
+// RenderForJSONAPI returns the JSON formatted version of this object that may be submitted to Pingdom
+func (t *Team) RenderForJSONAPI() string {
+	b := map[string]interface{}{
+		"name":       t.Name,
+		"member_ids": t.MemberIDs,
+	}
+	jsonBody, _ := json.Marshal(b)
+	return string(jsonBody)
+}
+
+// Valid Determines whether the Team contains valid fields.  This can be
+// used to guard against sending illegal values to the Pingdom API.
+func (t *Team) Valid() error {
+	if t.Name == "" {
+		return fmt.Errorf("Invalid value for `Name`.  Must contain non-empty string")
+	}
+
+	return nil
+}

--- a/pingdom/team_types_test.go
+++ b/pingdom/team_types_test.go
@@ -1,0 +1,27 @@
+package pingdom
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTeamValid(t *testing.T) {
+	team := Team{
+		Name:      "fake team",
+		MemberIDs: nil,
+	}
+	params := team.Valid()
+
+	assert.Equal(t, nil, params, "Team.Valid() should return nil if valid")
+}
+
+func TestTeamNotValid(t *testing.T) {
+	team := Team{
+		Name:      "",
+		MemberIDs: []int{1, 3},
+	}
+	params := team.Valid()
+
+	assert.NotEqual(t, nil, params, "Team.Valid() should return not nil if not valid")
+}


### PR DESCRIPTION
When I initially worked on https://github.com/russellcardullo/go-pingdom/pull/57 I believe that Pingdom had not added the `alerting` API (Teams and Contacts) to v3.1 (I could be mistaken, but :shrug:). As a result I deleted the old code for managing users and teams.

After reviewing the state of the world yesterday, it appears that we could re-add this functionality. However the API is pretty vastly different than before, and requires proper JSON (not query parameters) for submission. 
I've taken a crack at solving this, trying to stay as close to the lines given by the rest of the project, while enabling JSON-style POST/PUT requests where needed.

To be clear: This is one day of work, and _likely_ needs some tweaking/improvement before we should merge it in, but the acceptance tests work, and I think it's a good starting point.

Things I think we should discuss:
1. How I handled the JSON POST/PUT stuff
2. The lack of validation (In particular, I found that `provider` on `SMSNotification` stuff is very picky in their api) is probably not great, but was more than I was able to get to in a day
3. I've got some pretty repetitive structs (`SMSNotification` vs `SMSNotificationResponse`) that I tried to model off of what was already in project, but we could likely simplify for useability.
4. The `Create` calls don't update the passed in object to add the `ID` automatically. This seems to follow existing trends, but I would think that we might want to do that so that users can do `pingdom.Contacts.Create(&contact)` and subsequently `contact.ID`
5. I updated some casing stuff for go-lint, but that may not be the direction you'd like to take this. We can easily drop that commit.

@cce - You may be interested in this PR