### PR TITLE
Enable client API token to be set with environment variable PINGDOM_API_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ client, err := pingdom.NewClientWithConfig(pingdom.ClientConfig{
 })
 ```
 
+The `APIToken` can also implicitly be provided by setting the environment variable `PINGDOM_API_TOKEN`:
+
+```bash
+export PINGDOM_API_TOKEN=pingdom_api_token
+./your_application
+```
+
 ### CheckService ###
 
 This service manages pingdom Checks which are represented by the `Check` struct.

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -19,7 +19,6 @@ func init() {
 		runAcceptance = true
 
 		config := pingdom.ClientConfig{
-			APIToken: os.Getenv("PINGDOM_API_TOKEN"),
 			HTTPClient: &http.Client{
 				Timeout: time.Second * 10,
 			},

--- a/pingdom/pingdom.go
+++ b/pingdom/pingdom.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 )
 
@@ -46,8 +47,15 @@ func NewClientWithConfig(config ClientConfig) (*Client, error) {
 	}
 
 	c := &Client{
-		APIToken: config.APIToken,
-		BaseURL:  baseURL,
+		BaseURL: baseURL,
+	}
+
+	if config.APIToken == "" {
+		if envAPIToken, set := os.LookupEnv("PINGDOM_API_TOKEN"); set {
+			c.APIToken = envAPIToken
+		}
+	} else {
+		c.APIToken = config.APIToken
 	}
 
 	if config.HTTPClient != nil {

--- a/pingdom/pingdom_test.go
+++ b/pingdom/pingdom_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 
@@ -48,6 +49,30 @@ func TestNewClientWithConfig(t *testing.T) {
 	assert.Equal(t, http.DefaultClient, c.client)
 	assert.Equal(t, defaultBaseURL, c.BaseURL.String())
 	assert.NotNil(t, c.Checks)
+}
+
+func TestNewClientWithEnvAPITokenDoesNotOverride(t *testing.T) {
+	os.Setenv("PINGDOM_API_TOKEN", "envSetAwesome")
+	defer os.Unsetenv("PINGDOM_API_TOKEN")
+	c, err := NewClientWithConfig(ClientConfig{
+		APIToken: "key",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, http.DefaultClient, c.client)
+	assert.Equal(t, defaultBaseURL, c.BaseURL.String())
+	assert.NotNil(t, c.Checks)
+	assert.Equal(t, c.APIToken, "key")
+}
+
+func TestNewClientWithEnvAPITokenWorks(t *testing.T) {
+	os.Setenv("PINGDOM_API_TOKEN", "envSetAwesome")
+	defer os.Unsetenv("PINGDOM_API_TOKEN")
+	c, err := NewClientWithConfig(ClientConfig{})
+	assert.NoError(t, err)
+	assert.Equal(t, http.DefaultClient, c.client)
+	assert.Equal(t, defaultBaseURL, c.BaseURL.String())
+	assert.NotNil(t, c.Checks)
+	assert.Equal(t, c.APIToken, "envSetAwesome")
 }
 
 func TestNewRequest(t *testing.T) {


### PR DESCRIPTION
This would allow the [terraform provider](https://github.com/russellcardullo/terraform-provider-pingdom) to be implicitly configured with an environment variable instead of a terraform variable which can get unnecessarily awkward in CI environments.