### PR TITLE
Add option to create HTTP check with IPV6

### DIFF
--- a/pingdom/api_responses.go
+++ b/pingdom/api_responses.go
@@ -40,7 +40,7 @@ type CheckResponse struct {
 	Teams                    []CheckTeamResponse `json:"teams,omitempty"`
 	ResponseTimeThreshold    int                 `json:"responsetime_threshold,omitempty"`
 	ProbeFilters             []string            `json:"probe_filters,omitempty"`
-	IP6                      bool                `json:"ip6,omitempty"`
+	IPV6                     bool                `json:"ipv6,omitempty"`
 
 	// Legacy; this is not returned by the API, we backfill the value from the
 	// Teams field.

--- a/pingdom/check_types.go
+++ b/pingdom/check_types.go
@@ -32,6 +32,7 @@ type HttpCheck struct {
 	TeamIds                  []int             `json:"teamids,omitempty"`
 	VerifyCertificate        *bool             `json:"verify_certificate,omitempty"`
 	SSLDownDaysBefore        *int              `json:"ssl_down_days_before,omitempty"`
+	IPV6                     *bool             `json:"ipv6,omitempty"`
 }
 
 // PingCheck represents a Pingdom ping check.
@@ -120,6 +121,10 @@ func (ck *HttpCheck) PutParams() map[string]string {
 
 	if ck.SSLDownDaysBefore != nil {
 		m["ssl_down_days_before"] = strconv.Itoa(*ck.SSLDownDaysBefore)
+	}
+
+	if ck.IPV6 != nil {
+		m["ipv6"] = strconv.FormatBool(*ck.IPV6)
 	}
 
 	// ShouldContain and ShouldNotContain are mutually exclusive.

--- a/pingdom/check_types_test.go
+++ b/pingdom/check_types_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestHttpCheckPutParams(t *testing.T) {
 	verifyCertificate := true
+	ipv6 := true
 	sslDownDaysBefore := 10
 
 	tests := []struct {
@@ -33,6 +34,7 @@ func TestHttpCheckPutParams(t *testing.T) {
 				ResponseTimeThreshold: 2300,
 				VerifyCertificate:     &verifyCertificate,
 				SSLDownDaysBefore:     &sslDownDaysBefore,
+				IPV6:                  &ipv6,
 			},
 			wantParams: map[string]string{
 				"name":                   "fake check",
@@ -56,6 +58,7 @@ func TestHttpCheckPutParams(t *testing.T) {
 				"responsetime_threshold": "2300",
 				"verify_certificate":     "true",
 				"ssl_down_days_before":   "10",
+				"ipv6":                   "true",
 			},
 		},
 		{
@@ -109,6 +112,7 @@ func TestHttpCheckPutParams(t *testing.T) {
 
 func TestHttpCheckPostParams(t *testing.T) {
 	verifyCertificate := true
+	ipv6 := true
 	sslDownDaysBefore := 10
 
 	check := HttpCheck{
@@ -127,6 +131,7 @@ func TestHttpCheckPostParams(t *testing.T) {
 		ResponseTimeThreshold: 2300,
 		VerifyCertificate:     &verifyCertificate,
 		SSLDownDaysBefore:     &sslDownDaysBefore,
+		IPV6:                  &ipv6,
 	}
 	want := map[string]string{
 		"name":                   "fake check",
@@ -147,6 +152,7 @@ func TestHttpCheckPostParams(t *testing.T) {
 		"responsetime_threshold": "2300",
 		"verify_certificate":     "true",
 		"ssl_down_days_before":   "10",
+		"ipv6":                   "true",
 	}
 
 	params := check.PostParams()


### PR DESCRIPTION
This adds the ability to create an HTTP check with the IPV6 option checked. This also fixes `ip6` -> `ipv6` in the `CheckResponse` struct.

- Docs: https://docs.pingdom.com/api/#tag/Checks/paths/~1checks/post
- Example:

```
package main

import (
	"fmt"

	"github.com/russellcardullo/go-pingdom/pingdom"
)

func main() {
	client, _ := pingdom.NewClientWithConfig(pingdom.ClientConfig{
		APIToken: "token",
	})

	newCheck := pingdom.HttpCheck{Name: "Test Check", Hostname: "www.google.com", Resolution: 5}
	check, _ := client.Checks.Create(&newCheck)
	fmt.Printf("%+v\n", check)

	ipv6 := true
	newCheck2 := pingdom.HttpCheck{Name: "Test Check 2", Hostname: "www.google.com", Resolution: 5, IPV6: &ipv6}
	check2, _ := client.Checks.Create(&newCheck2)
	fmt.Printf("%+v\n", check2)
}
```


<img width="267" alt="Screen Shot 2021-10-06 at 2 08 05 PM" src="https://user-images.githubusercontent.com/3457341/136276586-4bc339d5-f3c3-436e-a4e7-fabef1b4b0ec.png">
<img width="321" alt="Screen Shot 2021-10-06 at 2 08 36 PM" src="https://user-images.githubusercontent.com/3457341/136276588-6ba33406-00fc-4c1a-b7b4-5432a1681343.png">

Closes #69 